### PR TITLE
Many defects and IPMI/BIOS/Network work [4/8]

### DIFF
--- a/crowbar_framework/app/models/deployer_service.rb
+++ b/crowbar_framework/app/models/deployer_service.rb
@@ -163,7 +163,8 @@ class DeployerService < ServiceObject
       @logger.debug("Deployer transition: Done Allocate admin address for #{name}")
 
       @logger.debug("Deployer transition: Allocate bmc address for #{name}")
-      result = ns.allocate_ip("default", "bmc", "host", name)
+      suggestion = node["crowbar_wall"]["ipmi"]["address"] rescue nil
+      result = ns.allocate_ip("default", "bmc", "host", name, suggestion)
       @logger.error("Failed to allocate bmc address for: #{node.name}: #{result[0]}") if result[0] != 200
       @logger.debug("Deployer transition: Done Allocate bmc address for #{name}")
 


### PR DESCRIPTION
```
BIOS/IPMI/NETWORK updates

IPMI Changes:
* Don't use crowbar user for now.  Use root until iDRAC and PEC issues are resolved
* Add setting dedicated mode for PER to ipmi code path
* Add discover role to get ipmi settings and write them on the wall (DE193)

Deployer Changes:
* Use the ipmi wall settings to suggest to the network barclamp (no toggle) (DE193)

Network Changes:
* Allocate IP can take a suggestion for the IP to allocate (DE193)
* Added deallocate_ip and disable_interface as REST API routines (DE175)
* Update the network barclamp to watch for delete and remove nodes (DE175)

Provisioner Changes:
* Add temp state delete-final that allows for bc's to search before actual delete
  (DE669 and DE667)
* Fix latent delete bug that wasn't deleting the node role.

DE672 was reviewed and already implemented.
```

 crowbar_framework/app/models/deployer_service.rb |    3 ++-
 1 files changed, 2 insertions(+), 1 deletions(-)
