### PR TITLE
fix apt config prompt and rabbit startup issues [1/5]

### DIFF
--- a/chef/cookbooks/repos/files/default/apt.conf
+++ b/chef/cookbooks/repos/files/default/apt.conf
@@ -1,1 +1,5 @@
 APT::Get::AllowUnauthenticated 1 ;
+Dpkg::Options {
+   "--force-confdef";
+   "--force-confnew";
+}


### PR DESCRIPTION
a) force dpkg to overwrite config files, rather than prompting users to select option (hangs chef client)
b) make sure rabbit MQ user is there with home directory, and update paths for plugin

 chef/cookbooks/repos/files/default/apt.conf |    4 ++++
 1 files changed, 4 insertions(+), 0 deletions(-)
