### PR TITLE
Pull changes from development into essex-hack [2/16]

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,7 +12,6 @@ This wiki maintains information about the operation of Crowbar. Documentation fo
 Please consult the release notes for known issues
 
 To build your own copy of Crowbar, consult the readme (https://github.com/dellcloudedge/crowbar/blob/master/README.build) in the crowbar repos. Some important notes about the build process: 
-* Build requires a component known as "sledgehammer" that is a CentOS based image for discovery. This TFTPboot image does not change often and is not part of the normal build steps. See the DellCloudEdge/crowbar-sledgehammer repo for details. 
 * Build process has been tested on Ubuntu 10.10 and CentOS
 
 With that said, from a fresh install off the crowbar-dev.iso, the next steps are:

--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -37,7 +37,7 @@ module BarclampLibrary
           intf, interface_list, tm = Barclamp::Inventory.lookup_interface_info(node, data["conduit"])
           return Network.new(net, data, intf, interface_list)
         end unless node[:crowbar][:network].nil?
-        Network.new(type, { "address" => node[:ipaddress] })
+        nil
       end
 
       def self.list_disks(node)

--- a/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
@@ -65,7 +65,7 @@ Dir.foreach("/sys/class/net") do |entry|
     mac_map[logical_name] = mac_addr.strip
     f.close
     if !File.exists?("/tmp/tcpdump.#{logical_name}.out")
-      System.background_time_command(45, true, logical_name, "ifconfig #{logical_name} up ; /opt/tcpdump/tcpdump -c 1 -lv -v -i #{logical_name} -a -e -s 1514 ether proto 0x88cc > /tmp/tcpdump.#{logical_name}.out")
+      System.background_time_command(45, true, logical_name, "ifconfig #{logical_name} up ; tcpdump -c 1 -lv -v -i #{logical_name} -a -e -s 1514 ether proto 0x88cc > /tmp/tcpdump.#{logical_name}.out")
       wait=true
     end
   end

--- a/chef/cookbooks/ohai/recipes/default.rb
+++ b/chef/cookbooks/ohai/recipes/default.rb
@@ -20,28 +20,6 @@
 Ohai::Config[:plugin_path] << node.ohai.plugin_path
 Chef::Log.info("ohai plugins will be at: #{node.ohai.plugin_path}")
 
-d = directory "/opt/tcpdump" do
-  owner 'root'
-  group 'root'
-  mode 0755
-  recursive true
-  action :nothing
-end
-d.run_action(:create)
-
-unless ::File.exists?("/opt/tcpdump/tcpdump")
-  provisioners = search(:node, "roles:provisioner-server")
-  provisioner = provisioners[0] if provisioners
-  web_port = provisioner["provisioner"]["web_port"]
-  address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(provisioner, "admin").address
-  f = remote_file "/opt/tcpdump/tcpdump" do
-    source "http://#{address}:#{web_port}/files/tcpdump"
-    mode "0755"
-    action :nothing
-  end
-  f.run_action(:create)
-end
-
 d = directory node.ohai.plugin_path do
   owner 'root'
   group 'root'

--- a/chef/data_bags/crowbar/bc-template-deployer.json
+++ b/chef/data_bags/crowbar/bc-template-deployer.json
@@ -4,6 +4,7 @@
   "attributes": {
     "deployer": {
       "use_allocate": true,
+      "ignore_address_suggestions": false,
       "bios_map": [
 	{ "pattern": "hadoop-(edgenode|.*namenode)", "bios_set": "Hadoop", "raid_set": "SingleRaid10" },
 	{ "pattern": "hadoop-.*", "bios_set": "Hadoop", "raid_set": "JBODOnly" },

--- a/chef/data_bags/crowbar/bc-template-deployer.schema
+++ b/chef/data_bags/crowbar/bc-template-deployer.schema
@@ -13,6 +13,7 @@
           "required": true,
           "mapping": {
             "use_allocate": { "type": "bool", "required": true },
+            "ignore_address_suggestions": { "type": "bool" },
             "bios_map": {
               "type": "seq",
               "required": true,

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -43,6 +43,8 @@ debs:
     - make
     - flex
     - bison
+  pkgs:
+    - tcpdump
 
 rpms:
   redhat-6.2:
@@ -58,9 +60,11 @@ rpms:
     - kernel-devel
     - gcc
     - glibc-devel
+  pkgs:
+    - tcpdump
 
-extra_files:
-  - http://www.tcpdump.org/release/libpcap-1.2.1.tar.gz
-  - http://www.tcpdump.org/release/tcpdump-4.2.1.tar.gz
+#extra_files:
+#  - http://www.tcpdump.org/release/libpcap-1.2.1.tar.gz
+#  - http://www.tcpdump.org/release/tcpdump-4.2.1.tar.gz
 
-build_cmd: build_tcpdump.sh
+#build_cmd: build_tcpdump.sh

--- a/crowbar_framework/app/models/deployer_service.rb
+++ b/crowbar_framework/app/models/deployer_service.rb
@@ -163,7 +163,10 @@ class DeployerService < ServiceObject
       @logger.debug("Deployer transition: Done Allocate admin address for #{name}")
 
       @logger.debug("Deployer transition: Allocate bmc address for #{name}")
-      result = ns.allocate_ip("default", "bmc", "host", name)
+      suggestion = node["crowbar_wall"]["ipmi"]["address"] rescue nil
+      role = RoleObject.find_role_by_name "deployer-config-#{inst}"
+      suggestion = nil if role and role.default_attributes["deployer"]["ignore_address_suggestions"]
+      result = ns.allocate_ip("default", "bmc", "host", name, suggestion)
       @logger.error("Failed to allocate bmc address for: #{node.name}: #{result[0]}") if result[0] != 200
       @logger.debug("Deployer transition: Done Allocate bmc address for #{name}")
 


### PR DESCRIPTION
Synchronize essex-hack with development. Among other things, this
pulls in:
- Numerous UI improvements.
- Enhancements and bugfixes galore in the dev tool and build system.
- Sledgehammer on CentOS 6.2 support.
- Somewhat more standardized patch management for our Chef and Rails
  patches.

This pull request series has been smoketested on virtual machines, and
is able to spin up vms in Nova using the dashboard.

 README.txt                                         |    1 -
 .../barclamp/libraries/barclamp_library.rb         |    2 +-
 .../ohai/files/default/plugins/crowbar.rb          |    2 +-
 chef/cookbooks/ohai/recipes/default.rb             |   22 --------------------
 chef/data_bags/crowbar/bc-template-deployer.json   |    1 +
 chef/data_bags/crowbar/bc-template-deployer.schema |    1 +
 crowbar.yml                                        |   12 +++++++---
 crowbar_framework/app/models/deployer_service.rb   |    5 +++-
 8 files changed, 16 insertions(+), 30 deletions(-)
