### PR TITLE
Make sure repo metadata is updated when the repositories on a system are updated. [1/5]

### DIFF
--- a/chef/cookbooks/repos/recipes/default.rb
+++ b/chef/cookbooks/repos/recipes/default.rb
@@ -46,7 +46,7 @@ if provisioner and states.include?(node[:state])
         template "/etc/apt/sources.list.d/10-barclamp-#{repo}.list" do
           source "10-crowbar-extra.list.erb"
           variables(:url => url)
-          notifies :run, "file[/tmp/.repo_update]", :immediately
+          notifies :create, "file[/tmp/.repo_update]", :immediately
         end
       end
     end
@@ -65,7 +65,7 @@ if provisioner and states.include?(node[:state])
       template "/etc/yum.repos.d/crowbar-#{repo}.repo" do
         source "crowbar-xtras.repo.erb"
         variables(:repo => repo, :url => url)
-        notifies :run, "file[/tmp/.repo_update]", :immediately
+        notifies :create, "file[/tmp/.repo_update]", :immediately
       end
     end
      bash "update software sources" do


### PR DESCRIPTION
This fixes the bug where we add or change the metadata for a repo 
but the nodes do not update themselves.
