### PR TITLE
Update the test framework to use a teamed network.json [3/7]

### DIFF
--- a/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
@@ -46,7 +46,8 @@ mac_addr=""
 wait=false
 Dir.foreach("/sys/class/net") do |entry|
   next if entry =~ /\./
-  next if entry =~ /br/
+  # We only care about actual physical devices.
+  next unless File.exists? "/sys/class/net/#{entry}/device"
   type = File::open("/sys/class/net/#{entry}/type").readline.strip rescue "0"
   if type == "1"
     s1 = File.readlink("/sys/class/net/#{entry}") rescue ""


### PR DESCRIPTION
In the process of adding support or this, I also added:
- Use screen to run the actaul installation of crowbar on the admin
  node.  This also makes the installation process much less fragile in
  the face of changing network interface configurations.
- Have the test framework kick off the admin node install via SSH
  instead of using the crowbar.hostname hack.
- Make crowbar_ohai ignore any network interfaces that are not
  directly backed by a physical device.  This makes the condiut
  mapping code much more stable when adding or removing devices that
  act like a virtual ethernet device.
  
  .../ohai/files/default/plugins/crowbar.rb          |    3 ++-
  1 files changed, 2 insertions(+), 1 deletions(-)
