### PR TITLE
Add support for using the admin node as a router for the bmc address range. [2/6]

### DIFF
--- a/chef/cookbooks/bmc-nat/recipes/client.rb
+++ b/chef/cookbooks/bmc-nat/recipes/client.rb
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2011 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Note : This script runs on both the admin and compute nodes.
+# It intentionally ignores the bios->enable node data flag.
+
+nets = node[:crowbar][:network] || return
+nets[:bmc] && nets[:admin] || return
+bmc_subnet    = nets[:bmc][:subnet]
+bmc_netmask   = nets[:bmc][:netmask]
+admin_subnet  = nets[:admin][:subnet]
+admin_netmask = nets[:admin][:netmask]
+nat_node = search(:node, "roles:bmc-nat-router")[0] rescue return
+nat_address = nat_node[:crowbar][:network][:admin][:address]
+
+return if admin_subnet == bmc_subnet && admin_netmask == bmc_netmask
+
+bash "Add route to get to our BMC via nat" do
+  code "ip route add #{bmc_subnet}/#{bmc_netmask} via #{nat_address}"
+  not_if "ip route show via #{nat_address} |grep -q #{bmc_subnet}"
+end

--- a/chef/cookbooks/bmc-nat/recipes/router.rb
+++ b/chef/cookbooks/bmc-nat/recipes/router.rb
@@ -1,0 +1,37 @@
+
+# Copyright (c) 2011 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Note : This script runs on both the admin and compute nodes.
+# It intentionally ignores the bios->enable node data flag.
+
+nets = node[:crowbar][:network] || return
+nets[:bmc] && nets[:admin] && nets[:bmc_vlan] || return
+bmc_subnet    = nets[:bmc][:subnet]
+bmc_netmask   = nets[:bmc][:netmask]
+admin_subnet  = nets[:admin][:subnet]
+admin_netmask = nets[:admin][:netmask]
+
+bash "Set up masquerading for the BMC network" do
+  code <<EOC
+iptables -t nat -F POSTROUTING
+iptables -t nat -A POSTROUTING -s #{admin_subnet}/#{admin_netmask} -d #{bmc_subnet}/#{bmc_netmask} -j SNAT --to-source #{nets[:bmc_vlan][:address]}
+iptables -P FORWARD DROP
+iptables -F FORWARD
+iptables -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+iptables -A FORWARD -s #{admin_subnet}/#{admin_netmask} -d #{bmc_subnet}/#{bmc_netmask} -j ACCEPT
+echo 1 >/proc/sys/net/ipv4/ip_forward
+EOC
+  not_if "iptables -t nat --list -n |grep #{nets[:bmc_vlan][:address]}"
+end

--- a/chef/roles/bmc-nat-client.rb
+++ b/chef/roles/bmc-nat-client.rb
@@ -1,0 +1,7 @@
+name "bmc-nat-client"
+description "Sets up routes to access BMC addresses"
+run_list(
+         "recipe[bmc-nat::client]"
+)
+default_attributes()
+override_attributes()

--- a/chef/roles/bmc-nat-router.rb
+++ b/chef/roles/bmc-nat-router.rb
@@ -1,0 +1,7 @@
+name "bmc-nat-router"
+description "Configures a node to nat to the BMC network"
+run_list(
+         "recipe[bmc-nat::router]"
+)
+default_attributes()
+override_attributes()


### PR DESCRIPTION
This pull request does two things:
- Add support for using the admin node as a router for the bmc
  address range.  
  
  If the BMC network and the admin network are not on the same
  subnet, we will configure the admin node to forward and DNAT any
  packets routed to it that need to go to the bmcs.  The rest of the
  nodes will route packets destined for the BMC address range to the
  admin node.
- Add support for configuring the bmcs to operate in tagged VLAN
  mode.
  
  This lets us logically seperate traffic for the bmcs, even if they
  are physically attached to the same switches.  
  
  chef/cookbooks/bmc-nat/recipes/client.rb         |   33 +++++++++++++++++++
  chef/cookbooks/bmc-nat/recipes/router.rb         |   37 ++++++++++++++++++++++
  chef/roles/bmc-nat-client.rb                     |    7 ++++
  chef/roles/bmc-nat-router.rb                     |    7 ++++
  crowbar_framework/app/models/deployer_service.rb |   18 +++++++----
  5 files changed, 96 insertions(+), 6 deletions(-)
