### PR TITLE
Add 10G and more support to the network subsystem [1/5]

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -76,8 +76,8 @@ module BarclampLibrary
 
       def self.sort_ifs(map, bus_order)
         answer = map.sort{|a,b|
-          aindex = Barclamp::Inventory.bus_index(bus_order, a[1])
-          bindex = Barclamp::Inventory.bus_index(bus_order, b[1])
+          aindex = Barclamp::Inventory.bus_index(bus_order, a[1]["path"])
+          bindex = Barclamp::Inventory.bus_index(bus_order, b[1]["path"])
           aindex == bindex ? a[0] <=> b[0] : aindex <=> bindex
         }
         answer.map! { |x| x[0] }
@@ -123,10 +123,14 @@ module BarclampLibrary
 
         sorted_ifs = Barclamp::Inventory.sort_ifs(if_list, bus_order)
         if_remap = {}
-        count = 1
+        count_map = {}
         sorted_ifs.each do |intf|
-          if_remap["1g#{count}"] = intf
-          count = count + 1
+          speeds = if_list[intf]["speeds"]
+          speeds.each do |speed|
+            count = count_map[speed] || 1
+            if_remap["#{speed}#{count}"] = intf
+            count_map[speed] = count + 1
+          end
         end
 
         ans = {}

--- a/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
@@ -13,6 +13,9 @@
 # limitations under the License.
 #
 
+require 'rubygems'
+require 'socket'
+require 'cstruct'
 require 'timeout'
 
 provides "crowbar_ohai"
@@ -33,6 +36,76 @@ class System
       system("/tmp/tcpdump-#{name}.sh")
     end
   end
+end
+
+# From: "/usr/include/linux/sockios.h"
+SIOCETHTOOL = 0x8946
+
+# From: "/usr/include/linux/ethtool.h"
+ETHTOOL_GSET = 1
+
+# From: "/usr/include/linux/ethtool.h"
+class EthtoolCmd < CStruct
+  uint32 :cmd
+  uint32 :supported
+  uint32 :advertising
+  uint16 :speed
+  uint8  :duplex
+  uint8  :port
+  uint8  :phy_address
+  uint8  :transceiver
+  uint8  :autoneg
+  uint8  :mdio_support
+  uint32 :maxtxpkt
+  uint32 :maxrxpkt
+  uint16 :speed_hi
+  uint8  :eth_tp_mdix
+  uint8  :reserved2
+  uint32 :lp_advertising
+  uint32 :reserved_a0
+  uint32 :reserved_a1
+end
+
+# From: "/usr/include/linux/ethtool.h"
+#define SUPPORTED_10baseT_Half      (1 << 0)
+#define SUPPORTED_10baseT_Full      (1 << 1)
+#define SUPPORTED_100baseT_Half     (1 << 2)
+#define SUPPORTED_100baseT_Full     (1 << 3)
+#define SUPPORTED_1000baseT_Half    (1 << 4)
+#define SUPPORTED_1000baseT_Full    (1 << 5)
+#define SUPPORTED_Autoneg           (1 << 6)
+#define SUPPORTED_TP                (1 << 7)
+#define SUPPORTED_AUI               (1 << 8)
+#define SUPPORTED_MII               (1 << 9)
+#define SUPPORTED_FIBRE             (1 << 10)
+#define SUPPORTED_BNC               (1 << 11)
+#define SUPPORTED_10000baseT_Full   (1 << 12)
+#define SUPPORTED_Pause             (1 << 13)
+#define SUPPORTED_Asym_Pause        (1 << 14)
+#define SUPPORTED_2500baseX_Full    (1 << 15)
+#define SUPPORTED_Backplane         (1 << 16)
+#define SUPPORTED_1000baseKX_Full   (1 << 17)
+#define SUPPORTED_10000baseKX4_Full (1 << 18)
+#define SUPPORTED_10000baseKR_Full  (1 << 19)
+#define SUPPORTED_10000baseR_FEC    (1 << 20)
+
+def get_supported_speeds(interface)
+  ecmd = EthtoolCmd.new
+  ecmd.cmd = ETHTOOL_GSET
+
+  ifreq = [interface, ecmd.data].pack("a16p")
+  sock = Socket.new(Socket::AF_INET, Socket::SOCK_DGRAM, 0)
+  sock.ioctl(SIOCETHTOOL, ifreq)
+
+  rv = ecmd.class.new
+  rv.data = ifreq.unpack("a16p")[1]
+
+  speeds = []
+  speeds << "10m" if (rv.supported & ((1<<0)|(1<<1)))
+  speeds << "100m" if (rv.supported & ((1<<2)|(1<<3)))
+  speeds << "1g" if (rv.supported & ((1<<5)|(1<<5)))
+  speeds << "10g" if (rv.supported & ((0xf<<17)|(1<<12)))
+  speeds
 end
 
 crowbar_ohai Mash.new
@@ -57,7 +130,8 @@ Dir.foreach("/sys/class/net") do |entry|
 
     crowbar_ohai[:detected] = Mash.new unless crowbar_ohai[:detected]
     crowbar_ohai[:detected][:network] = Mash.new unless crowbar_ohai[:detected][:network]
-    crowbar_ohai[:detected][:network][entry] = spath
+    speeds = get_supported_speeds(entry)
+    crowbar_ohai[:detected][:network][entry] = { :path => spath, :speeds => speeds }
 
     logical_name = entry
     networks << logical_name

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -69,6 +69,7 @@ gems:
   pkgs:
     - xml-simple
     - libxml-ruby
+    - cstruct
 
 build_cmd: build.sh
 


### PR DESCRIPTION
The network devices now have a list of supported speeds on their entries from ohai.

The network barclamp libraries will process the lists to handle entries like
10g1 and 100m3 and 1g3.  The patterns don't change.  Also, the json files
are not updated with this change.

WARNING: Some 10g devices don't support slower speeds and will disappear
from the 1g lists with this change.

 .../barclamp/libraries/barclamp_library.rb         |   14 +++--
 .../ohai/files/default/plugins/crowbar.rb          |   76 +++++++++++++++++++-
 crowbar.yml                                        |    1 +
 3 files changed, 85 insertions(+), 6 deletions(-)
