### PR TITLE
Add support for debian source repositories, and pull in the MySQL source code. [3/7]

### DIFF
--- a/chef/cookbooks/repos/recipes/default.rb
+++ b/chef/cookbooks/repos/recipes/default.rb
@@ -35,17 +35,17 @@ if provisioner and states.include?(node[:state])
     file "/etc/apt/sources.list" do
       action :delete
     end
-    repositories.each do |repo,url|
+    repositories.each do |repo,urls|
       case repo
       when "base"
         template "/etc/apt/sources.list.d/00-base.list" do
-          variables(:url => url)
+          variables(:urls => urls)
           notifies :create, "file[/tmp/.repo_update]", :immediately
         end
       else
         template "/etc/apt/sources.list.d/10-barclamp-#{repo}.list" do
           source "10-crowbar-extra.list.erb"
-          variables(:url => url)
+          variables(:urls => urls)
           notifies :create, "file[/tmp/.repo_update]", :immediately
         end
       end
@@ -61,10 +61,10 @@ if provisioner and states.include?(node[:state])
       code "yum clean expire-cache"
       action :nothing
     end
-    repositories.each do |repo,url|
+    repositories.each do |repo,urls|
       template "/etc/yum.repos.d/crowbar-#{repo}.repo" do
         source "crowbar-xtras.repo.erb"
-        variables(:repo => repo, :url => url)
+        variables(:repo => repo, :urls => urls)
         notifies :create, "file[/tmp/.repo_update]", :immediately
       end
     end

--- a/chef/cookbooks/repos/templates/default/10-crowbar-extra.list.erb
+++ b/chef/cookbooks/repos/templates/default/10-crowbar-extra.list.erb
@@ -1,1 +1,3 @@
-<%= @url %>
+<% @urls.keys.sort.each do |url| -%>
+<%= url %>
+<% end -%>

--- a/chef/cookbooks/repos/templates/default/crowbar-xtras.repo.erb
+++ b/chef/cookbooks/repos/templates/default/crowbar-xtras.repo.erb
@@ -1,4 +1,6 @@
 [crowbar-<%= @repo %>]
 name=Crowbar <%= @repo %> Packages
-<%= @url %>
+<% @urls.keys.sort.each do |url| -%>
+<%= url %>
+<% end -%>
 gpgcheck=0

--- a/chef/cookbooks/repos/templates/ubuntu-10.10/00-base.list.erb
+++ b/chef/cookbooks/repos/templates/ubuntu-10.10/00-base.list.erb
@@ -1,1 +1,3 @@
-deb <%= @url %> maverick main restricted
+<% @urls.keys.sort.each do |url| -%>
+deb <%= url %> maverick main restricted
+<% end -%>

--- a/chef/cookbooks/repos/templates/ubuntu-11.04/00-base.list.erb
+++ b/chef/cookbooks/repos/templates/ubuntu-11.04/00-base.list.erb
@@ -1,1 +1,3 @@
-deb <%= @url %> natty main restricted
+<% @urls.keys.sort.each do |url| -%>
+deb <%= url %> natty main restricted
+<% end -%>

--- a/chef/cookbooks/repos/templates/ubuntu-11.10/00-base.list.erb
+++ b/chef/cookbooks/repos/templates/ubuntu-11.10/00-base.list.erb
@@ -1,1 +1,4 @@
-deb <%= @url %> oneiric main restricted
+<% @urls.keys.sort.each do |url| -%>
+deb <%= url %> oneiric main restricted
+<% end -%>
+

--- a/chef/cookbooks/repos/templates/ubuntu-12.04/00-base.list.erb
+++ b/chef/cookbooks/repos/templates/ubuntu-12.04/00-base.list.erb
@@ -1,1 +1,3 @@
-deb <%= @url %> precise main restricted
+<% @urls.keys.sort.each do |url| -%>
+deb <%= url %> precise main restricted
+<% end -%>


### PR DESCRIPTION
This pull request adds the following features:

The provisioner and deployer can now handle having more than one repository
per barclamp.

The build system knows how to pull and cache Debian source bundles.

The MySQL barclam has been modified to pull the MySQL source corresponding to
the version of MySQL we are using on Ubuntu builds.

 chef/cookbooks/repos/recipes/default.rb            |   10 +++++-----
 .../templates/default/10-crowbar-extra.list.erb    |    4 +++-
 .../repos/templates/default/crowbar-xtras.repo.erb |    4 +++-
 .../repos/templates/ubuntu-10.10/00-base.list.erb  |    4 +++-
 .../repos/templates/ubuntu-11.04/00-base.list.erb  |    4 +++-
 .../repos/templates/ubuntu-11.10/00-base.list.erb  |    5 ++++-
 .../repos/templates/ubuntu-12.04/00-base.list.erb  |    4 +++-
 7 files changed, 24 insertions(+), 11 deletions(-)
