### PR TITLE
Update speed discovery to handle bad adapters [1/5]

### DIFF
--- a/chef/cookbooks/barclamp/libraries/test.rb
+++ b/chef/cookbooks/barclamp/libraries/test.rb
@@ -56,5 +56,17 @@ if $0 == __FILE__
       if_map=build_if_map %w{10m 100m 10g}
       assert_equal "10g", b.map_if_ref(if_map,"?1g1")
     end
+
+    def test_non_listed_items_with_one_valid
+      b = BarclampLibrary::Barclamp::Inventory
+      if_map=build_if_map %w{10m 100m 10g 0g 5k fred}
+      assert_equal "10g", b.map_if_ref(if_map,"?1g1")
+    end
+
+    def test_non_listed_items_with_no_valid
+      b = BarclampLibrary::Barclamp::Inventory
+      if_map=build_if_map %w{0g 5k fred}
+      assert_equal nil, b.map_if_ref(if_map,"?1g1")
+    end
   end
 end

--- a/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
@@ -96,22 +96,27 @@ class EthtoolValue < CStruct
 end
 
 def get_supported_speeds(interface)
-  ecmd = EthtoolCmd.new
-  ecmd.cmd = ETHTOOL_GSET
+  begin
+    ecmd = EthtoolCmd.new
+    ecmd.cmd = ETHTOOL_GSET
 
-  ifreq = [interface, ecmd.data].pack("a16p")
-  sock = Socket.new(Socket::AF_INET, Socket::SOCK_DGRAM, 0)
-  sock.ioctl(SIOCETHTOOL, ifreq)
+    ifreq = [interface, ecmd.data].pack("a16p")
+    sock = Socket.new(Socket::AF_INET, Socket::SOCK_DGRAM, 0)
+    sock.ioctl(SIOCETHTOOL, ifreq)
 
-  rv = ecmd.class.new
-  rv.data = ifreq.unpack("a16p")[1]
+    rv = ecmd.class.new
+    rv.data = ifreq.unpack("a16p")[1]
 
-  speeds = []
-  speeds << "10m" if (rv.supported & ((1<<0)|(1<<1))) != 0
-  speeds << "100m" if (rv.supported & ((1<<2)|(1<<3))) != 0
-  speeds << "1g" if (rv.supported & ((1<<4)|(1<<5))) != 0
-  speeds << "10g" if (rv.supported & ((0xf<<17)|(1<<12))) != 0
-  speeds
+    speeds = []
+    speeds << "10m" if (rv.supported & ((1<<0)|(1<<1))) != 0
+    speeds << "100m" if (rv.supported & ((1<<2)|(1<<3))) != 0
+    speeds << "1g" if (rv.supported & ((1<<4)|(1<<5))) != 0
+    speeds << "10g" if (rv.supported & ((0xf<<17)|(1<<12))) != 0
+    speeds
+  rescue Exception => e
+    puts "Failed to get ioctl for speed: #{e.message}"
+    speeds = [ "1g", "0g" ]
+  end
 end
 
 #
@@ -119,17 +124,22 @@ end
 # false for down
 # 
 def get_link_status(interface)
-  ecmd = EthtoolValue.new
-  ecmd.cmd = ETHTOOL_GLINK
+  begin
+    ecmd = EthtoolValue.new
+    ecmd.cmd = ETHTOOL_GLINK
 
-  ifreq = [interface, ecmd.data].pack("a16p")
-  sock = Socket.new(Socket::AF_INET, Socket::SOCK_DGRAM, 0)
-  sock.ioctl(SIOCETHTOOL, ifreq)
+    ifreq = [interface, ecmd.data].pack("a16p")
+    sock = Socket.new(Socket::AF_INET, Socket::SOCK_DGRAM, 0)
+    sock.ioctl(SIOCETHTOOL, ifreq)
 
-  rv = ecmd.class.new
-  rv.data = ifreq.unpack("a16p")[1]
+    rv = ecmd.class.new
+    rv.data = ifreq.unpack("a16p")[1]
 
-  rv.value != 0
+    rv.value != 0
+  rescue Exception => e
+    puts "Failed to get ioctl for link status: #{e.message}"
+    false
+  end
 end
 
 crowbar_ohai Mash.new


### PR DESCRIPTION
Some virtual adapters don't support the ethtool ioctl.
This fails and prevents the node from making progress.
Add an error message and force the speed to 1g and 0g.
0g indicates the error in the data space.

 chef/cookbooks/barclamp/libraries/test.rb          |   12 ++++
 .../ohai/files/default/plugins/crowbar.rb          |   58 ++++++++++++--------
 2 files changed, 46 insertions(+), 24 deletions(-)
