### PR TITLE
Add basic semi-functional support for UEFI netbooting [1/6]

### DIFF
--- a/chef/cookbooks/repos/recipes/default.rb
+++ b/chef/cookbooks/repos/recipes/default.rb
@@ -21,7 +21,7 @@ file "/tmp/.repo_update" do
   action :nothing
 end
 
-if provisioner
+if provisioner && (provisioner["provisioner"]["repositories"][os_token] rescue nil)
   web_port = provisioner["provisioner"]["web_port"]
   proxy = "http://#{provisioner.address.addr}:8123/"
   online = provisioner["provisioner"]["online"] rescue nil


### PR DESCRIPTION
This adds a basic level of support for using UEFI.

It just adds support into the provisioner for netbooting Sledgehammer
and the OS installers using elilo as the network bootloader.  It still
has significant limitations -- see README.uefi for more information.
