### PR TITLE
Barclamp import from legacy Crowbar.yml [1/6]

### DIFF
--- a/crowbar_framework/db/migrate/20120731230001_barclamp_import_deployer.rb
+++ b/crowbar_framework/db/migrate/20120731230001_barclamp_import_deployer.rb
@@ -1,0 +1,24 @@
+# Copyright 2012, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+class BarclampImportDeployer < ActiveRecord::Migration
+  def up
+    Barclamp.import_1x 'deployer'
+  end
+
+  def down
+    Barclamp.delete(Barclamp.find_by_name 'deployer')
+  end
+  
+end


### PR DESCRIPTION
This code imports the barclamp meta data from the crowbar.yml files
of the legacy barclamps.  

Migrations are used to manage this process, but the import code is in
the Barclamp model for DRY reasons.

Only Crowbar and Deployer barclamps are updated.  We can do the rest
after this has been reviewed.

Next step is to replace catalog.yml

 .../20120731230001_barclamp_import_deployer.rb     |   24 ++++++++++++++++++++
 1 files changed, 24 insertions(+), 0 deletions(-)
