### PR TITLE
Re-factor out inialize methods as it caused layout to fail in rails3 [2/11]

### DIFF
--- a/crowbar_framework/app/controllers/deployer_controller.rb
+++ b/crowbar_framework/app/controllers/deployer_controller.rb
@@ -14,8 +14,12 @@
 # 
 
 class DeployerController < BarclampController
-  def initialize
-    @service_object = DeployerService.new logger
+  before_filter :set_service_object
+ 
+  def set_service_object
+      @service_object = DeployerService.new logger
   end
+
+  private :set_service_object
 end
 


### PR DESCRIPTION
Fixed problem with layout rendering due to initialize method not calling super.  Refactored to use before_filter method to load @service_object and deleted initialize method.

 .../app/controllers/deployer_controller.rb         |   46 +++++++++++---------
 1 files changed, 25 insertions(+), 21 deletions(-)
