### PR TITLE
Add support to set the MTU for networks [1/2]

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -118,13 +118,17 @@ module BarclampLibrary
         conduits
       end
 
+      def self.get_detected_intfs(node)
+        node.automatic_attrs["crowbar_ohai"]["detected"]["network"]
+      end
+        
       def self.build_node_map(node)
         bus_order = Barclamp::Inventory.get_bus_order(node)
         conduits = Barclamp::Inventory.get_conduits(node)
 
         return {} if conduits.nil?
 
-        if_list = node.automatic_attrs["crowbar_ohai"]["detected"]["network"]
+        if_list = get_detected_intfs(node)
 
         # build a set of maps <intf-designator> -> <OS intf>
         # designators are <speed><#> (speed = 100m, 1g etc). # is a count of interfaces of the same speed.


### PR DESCRIPTION
The network json now supports specifying an mtu for networks. This value is configured on the appropriate interface (as long as its capable of handling large MTUs')
The intended use it to allow Jumbo frames to be used on 1g/10g NIC's

 .../barclamp/libraries/barclamp_library.rb         |   16 +++++++++++++++-
 1 files changed, 15 insertions(+), 1 deletions(-)
