### PR TITLE
Fix log rotation for chef components. [1/2]

### DIFF
--- a/chef/cookbooks/crowbar-hacks/recipes/default.rb
+++ b/chef/cookbooks/crowbar-hacks/recipes/default.rb
@@ -25,6 +25,15 @@ if states.include?(node[:state])
     end
   end
 
+  template "/etc/logrotate.d/chef" do
+    source "logrotate.erb"
+    owner "root"
+    group "root"
+    mode "0644"
+    variables(:logfiles => "/var/log/chef/client.log",
+              :postrotate => "bluepill chef-client restart")
+  end
+
   # Set up some basic log rotation
   template "/etc/logrotate.d/crowbar-webserver" do
     source "logrotate.erb"


### PR DESCRIPTION
Add the appropriate logrotate config file for chef-server and chef-client.

The prepackaged ones assumed that the old sysv init stuff was being used.
Since we run our chef components under bluepill, we need to use it to
bounce the service to let logrotation do it's thing.

 chef/cookbooks/crowbar-hacks/recipes/default.rb |    9 +++++++++
 1 file changed, 9 insertions(+)
