### PR TITLE
Nova monitoring, Nova volume, and log rotation fixes [2/4]

### DIFF
--- a/chef/cookbooks/crowbar-hacks/recipes/default.rb
+++ b/chef/cookbooks/crowbar-hacks/recipes/default.rb
@@ -49,7 +49,7 @@ if states.include?(node[:state])
     owner "root"
     group "root"
     mode "0644"
-    variables(:logfiles => "/var/log/nodes/*.log",
+    variables(:logfiles => "/var/log/nodes/*.log /var/log/nodes/.log",
               :postrotate => "/usr/bin/killall -HUP rsyslogd")
   end if node[:recipes].include?("logging::server")
   template "/etc/logrotate.d/client-join-logs" do


### PR DESCRIPTION
1. Make sure that /var/log/nodes/.log is rotated as rsyslog will sometimes recent messages without hostnames.
2. Nova monitoring improvements
   1. Add missing perl module for rabbitmq test
   2. Add nova-volume monitoring to nagios
   3. Fix the master nova subsystem monitor on the controller.
      1. track volumes
      2. fix permissions issue with running it.
3. Nova volume could only run on admin node.
   Greg had incorrectly assumed that nova-volume provided the api end point and this broken volume when
   when not on the controller.
   1. Move the nova-volume endpoint code into the api recipe.  
   2. Allow nova-volume to live on multiple nodes.
   
   chef/cookbooks/crowbar-hacks/recipes/default.rb |    2 +-
   1 files changed, 1 insertions(+), 1 deletions(-)
