### PR TITLE
Fix deployer and crowbar hash merge prevent admin [2/2]

### DIFF
--- a/crowbar_framework/app/models/deployer_service.rb
+++ b/crowbar_framework/app/models/deployer_service.rb
@@ -154,15 +154,13 @@ class DeployerService < ServiceObject
       end
 
       # Let it fly to the provisioner. Reload to get the address.
-      chash["crowbar"]["usedhcp"] = true
       if dep_config["deployer"]["use_allocate"] and !node.is_admin?
-        chash["crowbar"]["allocated"] = false
         node.allocated = false
       else
-        chash["crowbar"]["allocated"] = true
         node.allocated = true
       end
 
+      chash["crowbar"]["usedhcp"] = true
       prop_config.set_node_config_hash(node, chash)
       node.save
 


### PR DESCRIPTION
Deployer fix is to keep allocated from being a permanent config variable.

Crowbar barclamp fix allows the hashes to be merged in a sane way as opposed to
before where overwriting of network data occurred.

 crowbar_framework/app/models/deployer_service.rb |    4 +---
 1 files changed, 1 insertions(+), 3 deletions(-)
