### PR TITLE
Revert chef logging improvements. [1/1]

### DIFF
--- a/chef/roles/deployer-client.rb
+++ b/chef/roles/deployer-client.rb
@@ -2,7 +2,6 @@
 name "deployer-client"
 description "Deployer Client role - Discovery components"
 run_list(
-         "recipe[chef_handler]",
          "recipe[barclamp]",
          "recipe[repos]",
          "recipe[crowbar-hacks]",


### PR DESCRIPTION
The chef logging improvements are not compatible with Chef 0.10.6 on
Redhat.  We could resolve them by pulling in the right cookbook
(included by default in current versions of Chef), but that is
higher-impact than just not using improved logging for now.

 chef/roles/deployer-client.rb |    1 -
 1 file changed, 1 deletion(-)

Crowbar-Pull-ID: d0e9d83c60a7acb452585f33b8b1ffb1c45b4e9c

Crowbar-Release: fred
