### PR TITLE
Fix syntax error in deployer/crowbar.yml [1/1]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -51,8 +51,8 @@ rpms:
     - glibc-devel
   pkgs:
     - tcpdump
-	
-	
+
+
 gems:
   pkgs:
     - xml-simple


### PR DESCRIPTION
barclamp_install exit with this when using ruby 1.9:

/usr/lib64/ruby/1.9.1/psych.rb:203:in `parse':
(/opt/dell/barclamps/deployer/crowbar.yml): found a tab character that violate
intendation while a plain scalar at line 53 column 7 (Psych::SyntaxError)

The attached patch should fix that issue.

 crowbar.yml |    4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: 94ec2e15c0d9cbde0867a2736bb6f0cde73f80b8

Crowbar-Release: development
