### PR TITLE
Fixes for default BIOS configuration + enabling disabled boot sources in UEFI mode [1/1]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-deployer.json
+++ b/chef/data_bags/crowbar/bc-template-deployer.json
@@ -9,7 +9,7 @@
 	{ "pattern": "(hadoop|clouderamanager)-.*", "bios_set": "HadoopInfra", "raid_set": "SingleRaid10" },
         { "pattern": "nova-.*", "bios_set": "Virtualization", "raid_set": "SingleRaid10" },
         { "pattern": "swift-.*", "bios_set": "Storage", "raid_set": "JBODOnly" },
-        { "pattern": ".*", "bios_set": "HadoopInfra", "raid_set": "SingleRaid10" }
+        { "pattern": ".*", "bios_set": "Virtualization", "raid_set": "SingleRaid10" }
       ],
       "os_map": [ { "pattern": ".*", "install_os": "os_install" } ] 	  
     }


### PR DESCRIPTION
Fix for selecting Hadoop Infrastructure configuration as the default BIOS configuration
Utility methods to enable boot sources for a given boot mode

 chef/data_bags/crowbar/bc-template-deployer.json |    2 +-
 updates/wsman/lib/wsman.rb                       |   91 +++++++++++++++++++---
 2 files changed, 81 insertions(+), 12 deletions(-)

Crowbar-Pull-ID: 0adde687537604b4983d441d252843ed08fe9b84

Crowbar-Release: fred
