### PR TITLE
Hack up the deployer to find a provisioner for a node if one does not already exist. [1/1]

### DIFF
--- a/chef/cookbooks/barclamp/recipes/default.rb
+++ b/chef/cookbooks/barclamp/recipes/default.rb
@@ -17,3 +17,14 @@ class Chef::Recipe
   include BarclampLibrary
 end
 
+unless (node[:crowbar_wall][:provisioner_server] rescue nil)
+  provisioners = search(:node, "roles:provisioner-server")
+  if provisioners && provisioners[0]
+    provisioner = provisioners[0]
+    if provisioner[:provisioner] && provisioner[:provisioner][:web_port]
+      web_port = provisioner[:provisioner][:web_port]
+      node[:crowbar_wall] ||= Mash.new
+      node[:crowbar_wall][:provisioner_server] = "http://#{provisioner.address.addr}:#{web_port}"
+    end
+  end
+end


### PR DESCRIPTION
This is mainly for use by other barclamps so they don't have to.

 chef/cookbooks/barclamp/recipes/default.rb |   11 +++++++++++
 1 file changed, 11 insertions(+)

Crowbar-Pull-ID: 8b40f2e18a8f6b47b2e109973502e93cde4192b3

Crowbar-Release: development
