### PR TITLE
Avoid trying to install rubygem-cstruct more throughly when not on sleshammer. [2/2]

### DIFF
--- a/chef/cookbooks/ohai/recipes/default.rb
+++ b/chef/cookbooks/ohai/recipes/default.rb
@@ -15,16 +15,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 
 Ohai::Config[:plugin_path] << node.ohai.plugin_path
 Chef::Log.info("ohai plugins will be at: #{node.ohai.plugin_path}")
 
 # The crowbar ohai plugin requires rubygem-cstruct
-p = package "rubygem-cstruct" do
-  action :nothing
+if node["platform"] == "suse"
+  p = package "rubygem-cstruct" do
+    action :nothing
+  end
+  p.run_action(:install)
 end
-p.run_action(:install) if node["platform"] == "suse"
 
 d = directory node.ohai.plugin_path do
   owner 'root'


### PR DESCRIPTION
- We do not install OS packages on Sledgehammer as a matter of course, so do not do anything that will even try to trigger the package manager.  This fixes the initial chef-client run on the deployer.
- Keep a full transcript of every control.sh run on the deployer.
  
  chef/cookbooks/ohai/recipes/default.rb |   10 ++++++----
  1 file changed, 6 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: e702b3a21f5294cf6fa2c3851e3015ac5842fb49

Crowbar-Release: development
