### PR TITLE
Set default values for Attribs during template import [2/2]

### DIFF
--- a/crowbar_engine/barclamp_deployer/app/models/barclamp_deployer/barclamp.rb
+++ b/crowbar_engine/barclamp_deployer/app/models/barclamp_deployer/barclamp.rb
@@ -15,45 +15,5 @@
 
 # This class is the fall back class for barclamps that are missing Barclamp subclasses
 class BarclampDeployer::Barclamp < Barclamp
-=begin
-  def process_inbound_data jig_run, node, data
-    j
-    jig = jig_run.jig
-    maps = JigMap.where :jig_id=>jig.id, :barclamp_id=>self.id
-    maps.each do |map|
-      # there is only 1 map per barclamp/jig/attrib
-      a = map.attrib
-      # there can be multiple AttribInstances per node/barclamp instance
-      attribs = Attrib.where :attrib_id=>a.id, :node_id=>node.id
-      if attribs.empty?
-        # create the AIs for the data using the unbound role attribes that are already there
-        unset_attribs = Attrib.where :attrib_id=>a.id, :node_id => nil
-        unset_attribs.each do |na|
-          # attach node to barclamp data (from role association)
-          if na.barclamp.id == self.id
-            # create a node specific version of it
-            node_attrib = na.dup
-            node_attrib.node_id = node.id
-            node_attrib.save
-          end
-        end
-      end
-      # THIS NEEDS TO BE UPDATED TO ONLY UPDATE THE ACTIVE INSTANCES!
-      attribs.each do |ai|
-        # we only update the attribs linked to this barclamp 
-        # performance note: this is an expensive thing to figure out!
-        if !ai.role_instance_id.nil? and ai.barclamp.id == self.id 
-          # get the value
-          value = jig.find_attrib_in_data data, map.map
-          # store the value
-          target = Attrib.find ai.id
-          target.actual = value
-          target.jig_run_id = jig_run.id
-          target.save!
-        end
-      end
-    end
-    node
-  end
-=end
+
 end


### PR DESCRIPTION
The role.add_attrib was not storing the values from the import process.  This pull adds that 
feature.

 .../app/models/barclamp_deployer/barclamp.rb       |   42 +-------------------
 1 file changed, 1 insertion(+), 41 deletions(-)

Crowbar-Pull-ID: b42e0dba6ba371f2500d6076e85d7fedfb456ad0

Crowbar-Release: development
