### PR TITLE
Support admin node installation and node discovery on openSUSE 12.3 [3/3]

### DIFF
--- a/chef/cookbooks/ohai/recipes/default.rb
+++ b/chef/cookbooks/ohai/recipes/default.rb
@@ -20,14 +20,6 @@
 Ohai::Config[:plugin_path] << node.ohai.plugin_path
 Chef::Log.info("ohai plugins will be at: #{node.ohai.plugin_path}")
 
-# The crowbar ohai plugin requires rubygem-cstruct
-if node["platform"] == "suse"
-  p = package "rubygem-cstruct" do
-    action :nothing
-  end
-  p.run_action(:install)
-end
-
 d = directory node.ohai.plugin_path do
   owner 'root'
   group 'root'


### PR DESCRIPTION
This adds some tweaks to the logging, deployer and provisioner cookbooks to
be able to deploy the admin node on openSUSE 12.3

 chef/cookbooks/ohai/recipes/default.rb | 8 --------
 1 file changed, 8 deletions(-)

Crowbar-Pull-ID: 36fe5284bb2a9413ccbae3d00c1b19a7612ce79c

Crowbar-Release: development
