### PR TITLE
Fix Ruby 1.9 related syntax issues in the crowbar.yml files. [2/5]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -33,9 +33,9 @@ locale_additions:
   en:
     barclamp:
       deployer:
-        edit_attributes: 
+        edit_attributes:
           attributes: Attributes
-        edit_deployment: 
+        edit_deployment:
           deployment: Deployment
 
 debs:
@@ -63,8 +63,8 @@ rpms:
     - glibc-devel
   pkgs:
     - tcpdump
-	
-	
+
+
 gems:
   pkgs:
     - xml-simple


### PR DESCRIPTION
Ruby 1.9 barfs on some of the syntax in our crowbar.yml files due to
having a stricter notion of what is valid YML.

 crowbar.yml |    8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: ffc3762d231760e1644ae1583d71b1790716c46f

Crowbar-Release: feature/grizzly
