### PR TITLE
Backport the network recipies from Crowbar 2.0 [2/3]

### DIFF
--- a/chef/cookbooks/barclamp/libraries/ip.rb
+++ b/chef/cookbooks/barclamp/libraries/ip.rb
@@ -1,0 +1,351 @@
+# Base class to represent IP4 and IP6 addresses.
+# This class winds up delegating most of its work to
+# the IP::IP4 and IP::IP6 classes, which cannnot be directly created.
+# We strongly prefer to use CIDR address notation.
+class IP
+  include Comparable
+  protected
+
+  # Translate a CIDR subnet specification into a bitfield
+  # representing a netmask.
+  def subnet_to_mask
+    ((1 << @subnet) - 1) << (self.class::BITS - @subnet)
+  end
+
+  # Translate the address component of an IP address into
+  # an array consisting of the parts of the address.
+  def to_a
+    bits = @address
+    res = []
+    self.class::PARTS.times do
+      res << (bits & self.class::PART_MASK)
+      bits >>= self.class::BITS_PER_PART
+    end
+    res.reverse
+  end
+
+  # The IP4 and IP6 classes use the same initialization function.
+  # We handle 2 cases:
+  # One argument with the address in string form in CIDR format:
+  #   IP4: '127.0.0.1/8'
+  #   IP6: '::1/128'
+  # The first argument as an integer representaion of the address and an
+  # optional subnet as the second argument.
+  #
+  # In both cases, if the subnet is omitted it is assumed to be the numerically
+  # largest possible one for the address type, effectivly creating a single
+  # address range.
+  def initialize(*a)
+    if a[0].kind_of?(String)
+      self.address = a[0]
+    elsif a[0].kind_of?(Integer)
+      unless self.class::RANGE.include?(a[0].abs)
+        raise RangeError.new("Address #{a[0]} out of range for #{self.class.name}")
+      end
+      @address = a[0].abs
+      if a[1].kind_of?(Integer)
+        unless (0..self.class::BITS).include?(a[1])
+          raise RangeError.new("Subnet #{a[1]} out of range for #{self.class.name}")
+        end
+        @subnet = a[1]
+      else
+        @subnet = self.class.BITS
+      end
+    elsif a[0].kind_of?(self.class)
+      @address = a[0].address
+      @subnet = a[0].subnet
+    else
+      raise ArgumentError.new("Cannot create #{self.class.name} address out of #{a[0].inspect}")
+    end
+  end
+
+  public
+
+  # Coerce something into an IP4 or IP6 address, if possible.
+  def self.coerce(*a)
+    return a[0] if a[0].kind_of?(IP)
+    [::IP::IP4,::IP::IP6].each do |klass|
+      o = klass.new(*a) rescue false
+      return o if o
+    end
+    raise ArgumentError.new("#{a.inspect} cannot be coerced into an IP address")
+  end
+
+  # Bootstrap the rest of the methods Comparable provides.
+  def <=>(other)
+    other = ::IP.coerce(other)
+    raise ArgumentError.new("#{other} is not the same class as #{self}") unless
+      self.class == other.class
+    @address <=> other.address
+  end
+
+  # We will need this for mathy operators.
+  def to_i
+    @address.abs
+  end
+  alias address to_i
+
+  # This + Comparable lets us build and use Ranges out of IP addresses.
+  def succ
+    self.class.new((@address + 1), @subnet)
+  end
+
+  # Test to see if two addresses are in the same network.
+  def include?(other)
+    other = self.class.coerce(other)
+    raise ArgumentError.new("#{self.inspect} is not the same class as #{other.inspect}") unless other.class == self.class
+    (self.network..self.broadcast) === other
+  end
+
+  alias === include?
+
+  # Give us a nicer printed representation.
+  def inspect
+    "#<#{self.class.name}: #{to_s}>"
+  end
+
+  def subnet
+    @subnet
+  end
+
+  def subnet=(subn)
+    unless subn.to_i <= self.class::BITS
+      raise RangeError.new("#{name} subnets must be numbers <= #{self.class::BITS}")
+    end
+    @subnet = subn.to_i
+    self
+  end
+
+  def addr
+    to_s.split('/')[0]
+  end
+
+  # Get the network address for this address.
+  def network
+    self.class.new(@address & subnet_to_mask(), @subnet)
+  end
+
+  # Get the broadcast address for this address
+  def broadcast
+    self.network + ((1 << (self.class::BITS - @subnet)) - 1)
+  end
+
+  # Set a new address for this object.
+  def address=(address)
+    if address.kind_of?(String)
+      @address,s = self.class.parse_address(address)
+      if s
+        @subnet = s.to_i
+      elsif @subnet.nil?
+        @subnet = self.class::BITS
+      end
+    elsif address.kind_of?(Integer)
+      address = address.abs
+      raise RangeError.new("#{address} is out of range for #{self.class}") unless
+        self.class.RANGE.include?(address)
+      @address = address
+    else
+      raise ArgumentError.new("#{address} cannot be coerced into an IP address")
+    end
+    self
+  end
+
+  # Anything else, assume we want mathy goodness.
+  def method_missing(m,*args,&block)
+    self.class.new(case
+                   when (args and block_given?) then @address.send(m,*args,&block)
+                   when block_given? then @address.send(m,&block)
+                   when args then @address.send(m,*args)
+                   else @address.send(m)
+                   end.abs,
+                   @subnet)
+  end
+
+  class IP4 < IP
+    BITS=32
+    PARTS=4
+    RANGE=(0...(1 << BITS))
+    BITS_PER_PART=8
+    PART_MASK=(1 << BITS_PER_PART) - 1
+    MATCH_RE=/^(\d{1,3}\.){3}\d{1,3}$/
+
+    private
+    @address = nil
+    @subnet = nil
+
+    # Translate a netmask into a subnet.
+    # We explicitly only care about CIDR compatible netmasks,
+    # and will die horribly if someone wants to use a holey subnet.
+    def self.netmask_to_subnet(mask)
+      bits = mask.split('.').inject(0){|acc,i| acc = (acc << 8) + i.to_i}
+      res = 32
+      while bits[0] == 0
+        res-=1
+        bits >>= 1
+      end
+      while bits[0] == 1
+        bits >>= 1
+      end
+      if bits > 0
+        raise ArgumentError.new("#{mask} cannot be converted into a CIDR subnet!")
+      end
+      res
+    end
+
+    # Parse a string into an IP4 address or die trying
+    def self.parse_address(a)
+      addr,subnet = a.split('/',2)
+      if addr.kind_of?(String) && (addr =~ MATCH_RE)
+        addr = addr.split('.').map do |i|
+          i = i.to_i
+          if i >= 256
+            raise RangeError.new("#{i} is too big for an IP4 address!")
+          end
+          i
+        end.inject(0){|acc,i| acc = (acc << 8) + i}
+      else
+        raise ArgumentError.new("#{addr} is not a valid IP4 address!")
+      end
+      if subnet.kind_of?(String)
+        if subnet =~ MATCH_RE
+          subnet = self.netmask_to_subnet(subnet)
+        elsif subnet =~ /^\d+$/ && (subnet.to_i <= 32)
+          subnet = subnet.to_i
+        else
+          raise RangeError.new("#{subnet} is not a valid IP4 subnet!")
+        end
+      else
+        subnet = 32
+      end
+      [addr,subnet]
+    end
+
+    public
+
+    # Return the netmask in string format for our subnet
+    def netmask
+      bits = ~ ((1 << (BITS - @subnet)) - 1)
+      res = []
+      PARTS.times do
+        res << (bits & PART_MASK)
+        bits >>= BITS_PER_PART
+      end
+      res.reverse.join('.')
+    end
+
+    # Set our new subnet based on the passed netmask
+    def netmask=(mask)
+      @subnet = self.class.netmask_to_subnet(mask)
+      self
+    end
+
+    # Return out address in CIDR format.
+    def to_s
+      "#{to_a().join('.')}/#{@subnet}"
+    end
+
+    # Return our address in reverse DNS lookup format.
+    def reverse
+      "#{to_a.reverse.join('.')}.in-addr.arpa."
+    end
+  end
+
+  class IP6 < IP
+    BITS=128
+    PARTS=8
+    RANGE=(0...(1 << BITS))
+    BITS_PER_PART=16
+    PART_MASK=(1 << BITS_PER_PART) - 1
+    private
+    @address = nil
+    @subnet = nil
+
+    # Parse an IPv6 address or die trying.
+    # Parsing an IP6 address is fun due to its canonical representation.
+    def self.parse_address(a)
+      addr,subnet = a.split('/',2)
+      unless addr.kind_of?(String) && (addr =~ /^[0-9a-f:]+$/) &&
+          (! addr.include?(':::')) && addr.length >= 2
+        raise ArgumentError.new("#{addr} is not a valid IP6 address")
+      end
+      if addr.include?('::')
+        # Handle some degenerate cases first
+        addr = "0" + addr if addr[0..1] == '::'
+        addr << "0" if addr[-2..-1] == '::'
+        # By now, addr must at least equal '0::0'
+        addr = addr.split('::')
+        unless addr.length == 2 # only one '::' allowed!
+          raise ArgumentError.new("Only one :: allowed in an IP6 address!")
+        end
+        addr[0] = addr[0].split(':')
+        addr[2] = addr[1].split(':')
+        unless (addr[0].length + addr[2].length) <= PARTS
+          raise ArgumentError.new("#{addr} has too many parts!")
+        end
+        addr[1] = Array.new((PARTS - (addr[0].length + addr[2].length)),"0")
+        addr.flatten!
+      else
+        addr = addr.split(':')
+      end
+      unless addr.length == PARTS # An IP6 address has 8 elements
+        raise RangeError.new("#{addr} is incorrectly formatted.")
+      end
+      unless subnet.nil? || subnet.to_i <= BITS
+        raise RangeError.new("#{subnet} is out of range for an IP6 address.")
+      end
+      addr = addr.map do|i|
+        i = i.hex
+        if i > PART_MASK
+          raise RangeError.new("#{'%x' % i} is too big.")
+        else
+          i
+        end
+      end.inject(0){|acc,i| acc = (acc << BITS_PER_PART) + i}
+      [addr, subnet]
+    end
+
+    # Return the address component in canonical form.
+    def canonical_address
+      f = 0
+      in_run = false
+      runs = Array.new
+      a = self.to_a
+      a.each_index do |i|
+        if a[i] == 0 && i < (PARTS - 1)
+          f = i unless in_run
+          in_run = true
+        elsif in_run && (i == 7 || a[i].nonzero?)
+          len = i - f
+          runs[len] = [f,i] if len > 1 && runs[len].nil?
+          in_run = false
+        end
+      end
+      len = runs.length - 1
+      return a.map{|i| '%x' % i}.join(':') if len == -1
+      f,l = runs[len]
+      res = a[0...f].map{|i| '%x' % i}.join(':') + '::'
+      unless a[7].zero?
+        res += a[l..7].map{|i| '%x' % i}.join(':')
+      end
+      res
+    end
+
+    public
+
+    # Print our address in CIDR format
+    def to_s
+      "#{canonical_address}/#{@subnet}"
+    end
+
+    # Print our address in reverse DNS format.
+    def reverse
+      bits = @address
+      res = []
+      32.times do
+        res << '%x' % (bits & 15)
+        bits >>= 4
+      end
+      res.join('.') + ".ip6.arpa."
+    end
+  end
+end

--- a/chef/cookbooks/barclamp/libraries/nethelper.rb
+++ b/chef/cookbooks/barclamp/libraries/nethelper.rb
@@ -1,0 +1,27 @@
+class Chef
+  class Node
+    def all_addresses(type=::IP)
+      (self[:crowbar_wall][:network][:addrs].values || [] rescue []).flatten.map{|a|
+        ::IP.coerce(a)
+      }.select{|a|a.kind_of? type}
+    end
+    def addresses(net="admin",type=::IP)
+      (self[:crowbar_wall][:network][:addrs][net] || [] rescue []).map{|a|
+        ::IP.coerce(a)
+      }.select{|a|a.kind_of? type}
+    end
+    def address(net="admin",type=::IP)
+      self.addresses(net,type).first ||
+        (::IP.coerce("#{self[:crowbar][:network][net][:address]}/#{self[:crowbar][:network][net][:netmask]}") rescue nil) ||
+        ::IP.coerce(self[:ipaddress])
+    end
+    def interfaces(net="admin")
+      (self[:crowbar_wall][:network][:nets][net] || [] rescue []).map { |n|
+        ::Nic.new(n)
+      }
+    end
+    def interface(net="admin")
+      self.interfaces(net).last
+    end
+  end
+end

--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -1,0 +1,644 @@
+# Library of routines for handling network interfaces
+
+# Base class representing a network interface.
+class ::Nic
+  include Comparable
+  private
+  @@interfaces = Hash.new
+  @nic = nil
+  @nicdir = nil
+  @addresses = ::Array.new
+  @dependents = nil
+
+  # Helper method for reading values from sysfs for a nic.
+  def sysfs(file)
+    ::File.read("#{@nicdir}/#{file}").strip
+  end
+
+  def sysfs_put(file,val)
+    ::File.open("#{@nicdir}/#{file}","a+") do |f|
+      f.syswrite(val.to_s)
+    end
+  end
+
+  # Basic initialization routine for subclasses of Nic.
+  def initialize(nic)
+    @nic = nic.dup.freeze
+    @nicdir = "/sys/class/net/#{nic}".freeze
+    refresh()
+  end
+
+  # Helper for running ip commands.
+  def run_ip(arg)
+    ::Kernel.system("ip #{arg}")
+  end
+
+  # Return an unsorted array of all nics on the system.
+  def self.__nics
+    res = []
+    ::Dir.entries("/sys/class/net").each do |d|
+      next if d == '.' or d == '..'
+      next unless ::File.directory?("/sys/class/net/#{d}")
+      res << Nic.new(d)
+    end
+    res
+  end
+
+  public
+
+  # Return an array of all the nics present on the system.
+  # This array will be sorted in nic dependency order.
+  def self.nics
+    res = Array.new
+    Nic.__nics.each do |nic|
+      len = nic.dependents.length
+      res[len] ||= Array.new
+      res[len] << nic
+    end
+    res.compact.map{|r| r.sort}.flatten
+  end
+
+  def self.refresh_all
+    @@interfaces.each_value{|n|n.refresh}
+  end
+
+  # Some class functions for determining what kind of nic
+  # we are looking at.
+  def self.exists?(nic)
+    nic.kind_of?(::Nic) or
+      ::File.exists?("/sys/class/net/#{nic}")
+  end
+
+  def self.coerce(nic)
+    return nic if nic.kind_of?(::Nic)
+     ::Nic.new(nic)
+  end
+
+  def self.bridge?(nic)
+    nic.kind_of?(::Nic::Bridge) or
+      ::File.exists?("/sys/class/net/#{nic}/bridge/bridge_id")
+  end
+
+  def self.bond?(nic)
+    nic.kind_of?(::Nic::Bond) or
+      ::File.exists?("/sys/class/net/#{nic}/bonding/slaves")
+  end
+
+  def self.vlan?(nic)
+    nic.kind_of?(::Nic::Vlan) or
+      ::File.exists?("/proc/net/vlan/#{nic}")
+  end
+
+  # ifindex and iflink track parent -> child relationships
+  # among nics.  We only really use it for vlan nics for now.
+  def ifindex
+    sysfs("ifindex").to_i
+  end
+
+  def iflink
+    sysfs("iflink").to_i
+  end
+
+  # We only have this to reduce the number of times we have to call
+  # ip to get the addresses for an interface.  If we can get this
+  # info in a more efficient way (via an ioctl or whatever) it can go away.
+  def refresh
+    @addresses = ::Array.new
+    @dependents = nil
+    ::IO.popen("ip -o addr show dev #{@nic}") do |f|
+      f.each do |line|
+        parts = line.gsub('\\','').split
+        next unless parts[2] =~ /^inet/
+        next if parts[5] == 'link'
+        addr = IP.coerce(parts[3])
+        @addresses << addr
+      end
+    end
+    self
+  end
+
+  # Get a list of all IP4 and IP6 addresses bound to a nic.
+  def addresses
+    @addresses
+  end
+
+  # IP address manipulation routines
+  def add_address(addr)
+    addr = ::IP.coerce(addr).dup.freeze
+    return self if @addresses.include?(addr)
+    if run_ip("addr add #{addr.to_s} dev #{@nic}")
+      @addresses << addr
+      self
+    else
+      raise ::RuntimeError.new("Could not add #{addr.to_s} to #{@nic}")
+      false
+    end
+  end
+
+  def remove_address(addr)
+    addr = ::IP.coerce(addr)
+    return self unless @addresses.include?(addr)
+    unless run_ip("addr del #{addr.to_s} dev #{@nic}")
+      raise ::RuntimeError.new("Could not remove #{addr.to_s} from #{@nic}.")
+    end
+    @addresses.delete(addr)
+    self
+  end
+
+  # This kills all IP addresses and routes set to go through a nic.
+  # Use with caution.
+  def flush
+    run_ip("-4 route flush dev #{@nic}")
+    run_ip("-6 route flush dev #{@nic}")
+    run_ip("addr flush dev #{@nic}")
+    @addresses = ::Array.new
+    self
+  end
+
+  # Several helper routines for querying the state of a nic.
+
+  # Does this nic have a cable plugged in to it?
+  def link_up?
+    sysfs("carrier") == "1"
+  end
+
+  # Get the mac address of a nic.
+  def mac
+    sysfs("address") rescue "00:00:00:00:00:00"
+  end
+
+  # Get the speed a this nic is operating at.
+  # May not always be accurate.
+  def speed
+    sysfs("speed").to_i rescue 0
+  end
+
+  # Get and set the MTU for an interface.
+  def mtu
+    sysfs("mtu").to_i rescue 0
+  end
+
+  def mtu=(mtu)
+    run_ip("link set #{@nic} mtu #{mtu}")
+  end
+
+  def flags
+    sysfs("flags").hex
+  end
+
+  # Is this nic configured to be up?
+  def up?
+    (flags & 1) > 0
+  end
+
+  # Is this nic in broadcast mode?
+  def broadcast?
+    (flags & 2) > 0
+  end
+
+  def debug?
+    (flags & 4) > 0
+  end
+
+  # Is this a loopback interface?
+  def loopback?
+    (flags & 8) > 0
+  end
+
+  # Is this nic a pointtopoint interface?
+  def pointtopoint?
+    (flags & 16) > 0
+  end
+
+  # Is this nic operating in notrailers mode?
+  def notrailers?
+    (flags & 32) > 0
+  end
+
+  # Is this nic operating?
+  def running?
+    (flags & 64) > 0
+  end
+
+  # Is this nic in noarp mode?
+  def noarp?
+    (flags & 128) > 0
+  end
+
+  # Is this nic in promiscuous mode?
+  def promiscuous?
+    (flags & 256) > 0
+  end
+
+  def allmulti?
+    (flags & 512) > 0
+  end
+
+  # Is this nic a master (i.e, a bond)?
+  def master?
+    (flags & 1024) > 0
+  end
+
+  # Is this nic enalaved to something else?
+  def slave?
+    (flags & 2048) > 0
+  end
+
+  def multicast?
+    (flags & 4096) > 0
+  end
+
+  def portsel?
+    (flags & 8192) > 0
+  end
+
+  def automedia?
+    (flags & 16384) > 0
+  end
+
+  def dynamic?
+    (flags & 32786) > 0
+  end
+
+  # Set a nic to be up.
+  def up
+    return self if up?
+    run_ip("link set #{@nic} up")
+    self
+  end
+
+  # Set a nic to be down.
+  def down
+    return self unless up?
+    run_ip("link set #{@nic} down")
+    self
+  end
+
+  # Get the name of this nic.
+  def name
+    @nic
+  end
+
+  # The next two routines onlt really work for interfaces that
+  # are link-basd subinterfaces -- i.e, vlan interfaces and the like.
+  # They do not return useful information for bonds and bridges.
+  # Get this nic's parents based on ifindex -> iflink matching.
+  def parents
+    return [] if self.ifindex == self.iflink
+    self.class.__nics.select do |n|
+      (n.ifindex == self.iflink) && ! (n == self)
+    end
+  end
+
+  # Ditto, except get children instead.
+  def children
+    self.class.__nics.select do |n|
+      (n.iflink == self.ifindex) && ! ( n == self )
+    end
+  end
+
+  # Get the slaves of this interface.  Unless you are a bond or a bridge,
+  # you don't have any.  This is here promarily to make the sort logic
+  # a little simpler.
+  def slaves
+    []
+  end
+
+  # Return the bond we are enslaved to, or nil if we are not in a bond.
+  def bond_master
+    return nil unless File.exists?("#{@nicdir}/master")
+    Nic.new(File.readlink("#{@nicdir}/master").split('/')[-1])
+  end
+
+  # Return the bridge we are enslaved to, or nil if we are not in a bridge.
+  def bridge_master
+    return nil unless File.exists?("#{@nicdir}/brport/bridge")
+    Nic.new(File.readlink("#{@nicdir}/brport/bridge").split('/')[-1])
+  end
+
+  # Return the interface we are enslaved to, if we are enslaved to something.
+  def master
+    self.bond_master || self.bridge_master
+  end
+
+  # Figure out all the interfaces we depend on.
+  def dependents
+    return @dependents if @dependents
+    res = self.parents
+    res.dup.each do |d|
+      res = res + d.dependents
+    end
+    res = res + slaves
+    slaves.each do |s|
+      res = res + s.dependents
+    end
+    @dependents = res
+    res
+  end
+
+  def <=>(other)
+    case
+    when self.name == other.name then 0
+    when self.name == "lo" then -1
+    when other.name == "lo" then 1
+    when self.dependents.member?(other) then 1
+    when other.dependents.member?(self) then -1
+    else self.name <=> other.name
+    end
+  end
+
+  def to_s
+    @nic
+  end
+
+  # Base case for the destroy function.
+  # Children of Nic should actually destroy themselves instead of
+  # leaving themselves unconfigured and down.
+  # Note that destroy also destroys any children of this nic.
+  # Use with care.
+  def destroy
+    children.each do |child|
+      child.destroy
+    end
+    master = self.master()
+    master.remove_slave(self) if master
+    self.flush
+    self.down
+    @@interfaces.delete(@nic)
+  end
+
+  # Override the usual new function for Nic.  All nic types shold
+  # be created through Nic.new, and not through the subclasses.
+  # Nic.new is intended to instantiate an object that tracks a nic
+  # that is already present on the system.
+  # If you want to create a new interface, call one of the
+  # create methods on a subclass.
+  def self.new(nic)
+    if o = @@interfaces[nic]
+      return o
+    elsif vlan?(nic)
+      o = ::Nic::Vlan.allocate
+    elsif bridge?(nic)
+      o = ::Nic::Bridge.allocate
+    elsif bond?(nic)
+      o = ::Nic::Bond.allocate
+    elsif exists?(nic)
+      o = ::Nic.allocate
+    else
+      raise ArgumentError.new("#{nic} does not exist!  Did you mean Nic.create?")
+    end
+    o.send(:initialize, nic)
+    @@interfaces[nic] = o
+    return o
+  end
+
+  # Base class for a bond.
+  # We handle all bond manipulation via sysfs for maximum flexibility.
+  class ::Nic::Bond < ::Nic
+    MASTER='/sys/class/net/bonding_masters'
+
+    private
+    def self.kill_bond(nic)
+      ::File.open(MASTER,"w") do |f|
+        f.write("-#{nic}")
+      end
+    end
+
+    def self.create_bond(nic)
+      ::File.open(MASTER,"w") do |f|
+        f.write("+#{nic}")
+      end
+      unless ::File.exists?("/sys/class/net/#{nic}")
+        self.kill_bond(nic)
+        raise ::RuntimeError.new("Could not create bond #{net}")
+      end
+    end
+
+    public
+
+    def slaves
+      sysfs("bonding/slaves").split.map{|i| ::Nic.new(i)}
+    end
+
+    def add_slave(slave)
+      unless ::Nic.exists?(slave)
+        raise ::ArgumentError.new("#{slave} does not exist, cannot add to bond #{@nic}")
+      end
+      slave = Nic.coerce(slave)
+      return slave if self.slaves.member?(slave)
+      if current_master = slave.master()
+        current_master.remove_slave(slave)
+      end
+      new_addrs = slave.addresses
+      slave.flush
+      slave.down
+      new_addrs.each{|a|self.add_address a}
+      sysfs_put("bonding/slaves","+#{slave}")
+      slave
+    end
+
+    def remove_slave(slave)
+      slave = self.class.coerce(slave)
+      unless self.slaves.member?(slave)
+        raise ::ArgumentError.new("#{slave} is not a member of bond #{@nic}")
+      end
+      sysfs_put("bonding/slaves","-#{slave}")
+      slave
+    end
+
+    def mode
+      sysfs("bonding/mode").split[1].to_i
+    end
+
+    def mode=(new_mode)
+      begin
+        self.down
+        sysfs_put("bonding/mode",new_mode)
+      ensure
+        self.up
+      end
+      self
+    end
+
+    def miimon
+      sysfs("bonding/miimon").to_i
+    end
+
+    def miimon=(millisecs)
+      sysfs_put("bonding/miimon",millisecs)
+      self
+    end
+
+    def down
+      slaves.each{|s|s.down}
+      super
+    end
+
+    def up
+      super
+      slaves.each{|s|s.up}
+      self
+    end
+
+    def destroy
+      slaves.each do |slave|
+        remove_slave(slave)
+      end
+      super
+      ::Nic::Bond.kill_bond(@nic)
+      nil
+    end
+
+    def self.create(nic,mode=6,miimon=100)
+      if self.exists?(nic)
+        raise ::ArgumentError.new("#{nic} already exists.")
+      elsif ! ::File.exists?("/sys/module/bonding")
+        unless ::Kernel.system("modprobe bonding")
+          raise ::RuntimeError.new("Unable to load bonding module.")
+        end
+        # Kill any bonds that were automatically created
+        ifs = ::File.read(MASTER).strip.split.each do |i|
+          self.kill_bond(i)
+        end
+      end
+      self.create_bond(nic)
+      iface = ::Nic.new(nic)
+      iface.mode = mode
+      iface.miimon = miimon
+      iface.up
+      iface
+    end
+  end
+
+  # Base class for a bridge.  We handle most bridge manipulation via brctl.
+  class ::Nic::Bridge < ::Nic
+    def slaves
+      ::Dir.entries("#{@nicdir}/brif").reject do |i|
+        i == '.' || i == '..'
+      end.map{|i| ::Nic.new(i)}
+    end
+
+    def add_slave(slave)
+      slave = self.class.coerce(slave)
+      unless ::Nic.exists?(slave)
+        raise ::ArgumentError.new("#{slave} does not exist, cannot add to bridge#{@nic}")
+      end
+      return if self.slaves.member?(slave)
+      if current_master = slave.master()
+        current_master.remove_slave(slave)
+      end
+      slave.up
+      new_addrs = slave.addresses
+      slave.flush
+      new_addrs.each{|a|self.add_address a}
+      ::Kernel.system("brctl addif #{@nic} #{slave}")
+    end
+
+    def remove_slave(slave)
+      slave = self.class.coerce(slave)
+      unless self.slaves.member?(slave)
+        raise ::ArgumentError.new("#{slave} is not a member of bridge #{@nic}")
+      end
+      ::Kernel.system("brctl delif #{@nic} #{slave}")
+      slave.down
+    end
+
+    def stp
+      sysfs("bridge/stp_state").to_i == 1
+    end
+
+    def stp=(val)
+      sysfs_put("bridge/stp_state",
+                case val
+                when true then 1
+                when false then 0
+                else raise ::ArgumentError.new("Bridge STP state must be either true or false.")
+                end)
+      self
+    end
+
+    def forward_delay
+      sysfs("bridge/forward_delay").to_i
+    end
+
+    def forward_delay=(delay)
+      sysfs_put("bridge/forward_delay",delay)
+      self
+    end
+
+    def up
+      slaves.each{|s|s.up}
+      super
+    end
+
+    def destroy
+      slaves.each do |slave|
+        remove_slave(slave)
+      end
+      super
+      ::Kernel.system("brctl delbr #{@nic}")
+      nil
+    end
+
+    def self.create(nic,slaves=[])
+      if self.exists?(nic)
+        raise ::ArgumentError.new("#{nic} already exists.")
+      end
+      unless ::File.exists?("/sys/module/bridge")
+        ::Kernel.system("modprobe bridge")
+      end
+      ::Kernel.system("brctl addbr #{nic}")
+      iface = ::Nic.new(nic)
+      slaves.each do |slave|
+        iface.add_slave slave
+      end
+      iface.up
+      iface
+    end
+  end
+
+  # Base class for a vlan nic.
+  # All vlan nics must be created as link types on a parent nic.
+  class ::Nic::Vlan < ::Nic
+    def vlan
+      ::IO.readlines("/proc/net/vlan/config").each do |line|
+        line = line.split('|')
+        next unless line[0].strip == @nic
+        return line[1].strip.to_i
+      end
+    end
+
+    def destroy
+      super
+      ::Kernel.system("vconfig rem #{@nic}")
+      nil
+    end
+
+    def up
+      parents.each{|p|p.up}
+      super
+    end
+
+    def self.create(parent,vlan)
+      nic = "#{parent}.#{vlan}"
+      if self.exists?(nic)
+        raise ::ArgumentError.new("#{nic} already exists.")
+      end
+      unless self.exists?(parent)
+        raise ::ArgumentError.new("Parent #{parent} for #{nic} does not exist")
+      end
+      unless (0..4095).member?(vlan)
+        raise ::RangeError.new("#{vlan} must be between 1 and 4095.")
+      end
+      unless ::File.exists?("/sys/module/8021q")
+        ::Kernel.system("modprobe 8021q")
+      end
+      parent.up
+      Kernel.system("vconfig set_name_type DEV_PLUS_VID_NO_PAD")
+      Kernel.system("vconfig add #{parent} #{vlan}")
+      n = ::Nic.new(nic)
+      n.up
+      n
+    end
+  end
+end


### PR DESCRIPTION
This backports the network barclamp recipies from Crowbar 2.0 into Pebbles.

From the original commit:

Rewrite network barclamp to manage interfaces directly.

```
Making the distro tools handle reconfiguring network interfaces for us
was needlessly fragile, since we were rewriting the network config and
changing the state of the interfaces while we were in the middle of
converging the node -- if we happened to do anything that would try to
talk to the chef-server while any of the interfaces needed to talk to
the admin network was changing, we could easily wind up in a state
where manual intervention would be needed to recover.

Additionally, the network barclamp had to have a good deal of
special-casing to handle all the distro-specific caveats that went
along with using ifup/ifdown directly to manage the nics.

This code does away with all that by teaching the network barclamp how
to manage our interfaces directly, reducing the distro-specific code
to what is needed to write out the proper configuation for ifup/ifdown
on the operating system.

New features:

 * All interface manipulation happens early in the compile phase of
   the chef-client runs, and the recipe will pause for up to 60
   seconds to verify that it can ping the node with the provisioner
   role (if one is assigned).  This should ensure that the chef-client
   run succeeds with minimal delay even when we are forced to do
   something that may trigger a spanning tree update on the
   network. This frees the rest of the barclamps from having to care
   about sleeping due to network configuration changes.
 * The network barclamp posts its state on
   node[:crowbar_wall][:network] to allow other barclamps to easily
   see what interfaces are members of what network and what IP
   addresses are assigned to the node.
 * Switching between single, dual, and team mode is more or less
   seamless now. You can easily switch network modes even when nova VMs are
   up and running without dropping more than a packet or two. The sole
   exception I have seen is Nova running in tenant_vlan mode.
 * It is trivial to deploy with a configuration that does not use vlan
   tagging at all.  The network barclamp will manage our interfaces
   correctly by assigning multiple IP addresses to the appropriate
   interfaces for each network, and it will handle moving addresses
   and routes around as needed.  Debian and Redhat config file
   generation has been updated to handle binding multiple IP addresses
   to interfaces so that a rebooted node will come up with the proper
   configuration before chef-client runs.
 * Helper classes have been added to the barclamp recipe that model IP
   addresses (including IP address ranges) and network interfaces.
   Those helpers also inject convienenece routines into the CHef::Node
   class to make it easier to find interfaces and addresses for each
   of our networks.
```

 chef/cookbooks/barclamp/libraries/ip.rb        |  351 +++++++++++++
 chef/cookbooks/barclamp/libraries/nethelper.rb |   27 +
 chef/cookbooks/barclamp/libraries/nic.rb       |  644 ++++++++++++++++++++++++
 3 files changed, 1022 insertions(+)

Crowbar-Pull-ID: 57b4821d276e5da97e9a031ecb6ab6c94f74ce80

Crowbar-Release: pebbles
