### PR TITLE
Make the network recipe die informativly if conduit mapping is insane. [1/2]

### DIFF
--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -463,6 +463,25 @@ class ::Nic
 
     public
 
+    # Find a bond that includes these nics.
+    def self.find(nics)
+      t = Hash.new
+      nics.each do |n|
+        n = Nic.coerce(n)
+        t[n.name]=n
+      end
+      self.__nics.each do |nic|
+        next unless Nic.bond?(nic)
+        q = Hash.new
+        nic.slaves.each do |n|
+          q[n.name] = n
+        end
+        next unless t == q
+        return nic
+      end
+      nil
+    end
+
     def slaves
       sysfs("bonding/slaves").split.map{|i| ::Nic.new(i)}
     end


### PR DESCRIPTION
If the network barclamp was handed an obviously insane conduit mapping
(one that contains either nils or references to interfaces that do not
exist), die with an informative error message instead of a more opaque one.

 chef/cookbooks/barclamp/libraries/nic.rb |   13 +++++++++++--
 1 file changed, 11 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: 4e6cc193a8cbbe598d32acfed9e47d422573a504

Crowbar-Release: pebbles
