### PR TITLE
crowbar-hacks: Update for new crowbar_join log location

### DIFF
--- a/chef/cookbooks/crowbar-hacks/recipes/default.rb
+++ b/chef/cookbooks/crowbar-hacks/recipes/default.rb
@@ -57,7 +57,7 @@ if states.include?(node[:state])
     owner "root"
     group "root"
     mode "0644"
-    variables(:logfiles => ["/var/log/crowbar-*.log","/var/log/crowbar-*.err"])
+    variables(:logfiles => ["/var/log/crowbar/crowbar_join/*"])
   end unless node[:recipes].include?("crowbar")
 end
 


### PR DESCRIPTION
This should go in once https://github.com/crowbar/barclamp-provisioner/pull/127 is accepted.
