### PR TITLE
Fixing segfault in wsman commands [1/1]

### DIFF
--- a/updates/wsman/lib/wsman.rb
+++ b/updates/wsman/lib/wsman.rb
@@ -89,7 +89,7 @@ class Crowbar
     filename = WSMAN.certname(@host)
     output = ""
     ret=0
-    stdargs = "-N root/dcim -v -o -j utf-8 -y basic"
+    stdargs = "-N root/dcim -v -V -o -j utf-8 -y basic"
     self.measure_time "WSMAN #{action} #{url} call" do
       cmd = "wsman #{action} #{url} -h #{@host} -P #{@port} -u #{@user} -p #{@password} -c #{filename} #{stdargs} #{args} 2>&1"
       output = %x{#{cmd}}


### PR DESCRIPTION
Disabling peer cert verification check - new version of libnss in updated sledgehammer seg-faults 

 updates/wsman/lib/wsman.rb |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 007e4a13170e228a358e936b3b78f9832cf76746

Crowbar-Release: pebbles
