### PR TITLE
Fixing segmentation fault in wsman code [1/1]

### DIFF
--- a/updates/wsman/lib/wsman.rb
+++ b/updates/wsman/lib/wsman.rb
@@ -89,7 +89,7 @@ class Crowbar
     filename = WSMAN.certname(@host)
     output = ""
     ret=0
-    stdargs = "-N root/dcim -v -o -j utf-8 -y basic"
+    stdargs = "-N root/dcim -v -V -o -j utf-8 -y basic"
     self.measure_time "WSMAN #{action} #{url} call" do
       cmd = "wsman #{action} #{url} -h #{@host} -P #{@port} -u #{@user} -p #{@password} -c #{filename} #{stdargs} #{args} 2>&1"
       output = %x{#{cmd}}


### PR DESCRIPTION
Blocking peer cert verification due to issues with libnss3 - due to upgraded libnss3 packages (in sledgehammer) wsman commands seg fault

 updates/wsman/lib/wsman.rb |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 4084dbf62f1e1b28f42a39fa476a5e81d83d0331

Crowbar-Release: mesa-1.6
