### PR TITLE
Fixing segmentation fault in wsman code [1/1]

### DIFF
--- a/updates/wsman/lib/wsman.rb
+++ b/updates/wsman/lib/wsman.rb
@@ -89,7 +89,7 @@ class Crowbar
     filename = WSMAN.certname(@host)
     output = ""
     ret=0
-    stdargs = "-N root/dcim -v -o -j utf-8 -y basic"
+    stdargs = "-N root/dcim -v -V -o -j utf-8 -y basic"
     self.measure_time "WSMAN #{action} #{url} call" do
       cmd = "wsman #{action} #{url} -h #{@host} -P #{@port} -u #{@user} -p #{@password} -c #{filename} #{stdargs} #{args} 2>&1"
       output = %x{#{cmd}}


### PR DESCRIPTION
Blocking peer cert verification due to issues with libnss3 - due to update libnss package (in sledgehammer) wsman code seg faults

 updates/wsman/lib/wsman.rb |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 1f1605de8dc9739d69aa3e2557968786a568ebf9

Crowbar-Release: hadoop-2.3
