### PR TITLE
Create a workaround for systems not supporting /etc/sysctl.d

### DIFF
--- a/chef/cookbooks/crowbar-hacks/files/default/reload-sysctl-d.cron
+++ b/chef/cookbooks/crowbar-hacks/files/default/reload-sysctl-d.cron
@@ -1,0 +1,4 @@
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+@reboot root find /etc/sysctl.d/ -type f -print | sort | xargs -r -n1 sysctl -e -q -p

--- a/chef/cookbooks/crowbar-hacks/recipes/default.rb
+++ b/chef/cookbooks/crowbar-hacks/recipes/default.rb
@@ -17,50 +17,63 @@
 # but that do not really belong with any specific barclamp.
 
 states = [ "ready", "readying", "recovering", "applying" ]
-if node["platform"] != "suse" and states.include?(node[:state])
-  # Don't waste time with mlocate or updatedb
-  %w{mlocate mlocate.cron updatedb}.each do |f|
-    file "/etc/cron.daily/#{f}" do
-      action :delete
+if states.include?(node[:state])
+  if node["platform"] != "suse"
+    # Don't waste time with mlocate or updatedb
+    %w{mlocate mlocate.cron updatedb}.each do |f|
+      file "/etc/cron.daily/#{f}" do
+        action :delete
+      end
+    end
+
+    template "/etc/logrotate.d/chef" do
+      source "logrotate.erb"
+      owner "root"
+      group "root"
+      mode "0644"
+      variables(:logfiles => "/var/log/chef/client.log",
+                :postrotate => "bluepill chef-client restart")
+    end
+
+    # Set up some basic log rotation
+    template "/etc/logrotate.d/crowbar-webserver" do
+      source "logrotate.erb"
+      owner "root"
+      group "root"
+      mode "0644"
+      variables(:logfiles => "/opt/dell/crowbar_framework/log/*.log",
+                  :action => "create 644 crowbar crowbar",
+                :postrotate => "/usr/bin/killall -USR1 rainbows")
+    end if node[:recipes].include?("crowbar")
+    template "/etc/logrotate.d/node-logs" do
+      source "logrotate.erb"
+      owner "root"
+      group "root"
+      mode "0644"
+      variables(:logfiles => "/var/log/nodes/*.log /var/log/nodes/.log",
+                :postrotate => "/usr/bin/killall -HUP rsyslogd")
+    end if node[:recipes].include?("logging::server")
+    template "/etc/logrotate.d/client-join-logs" do
+      source "logrotate.erb"
+      owner "root"
+      group "root"
+      mode "0644"
+      variables(:logfiles => ["/var/log/crowbar/crowbar_join/*"])
+    end unless node[:recipes].include?("crowbar")
+  end
+  # Note: Hacks that are needed on SUSE platforms as well too come here
+
+  if platform?("suse", "redhat", "centos")
+    # Workaround sysctl not loading configs from /etc/sysctl.d/
+    # during reboot
+    directory "create /etc/sysctl.d for reload-sysctl.d cronjob" do
+      path "/etc/sysctl.d"
+      mode "755"
+    end
+    cookbook_file "/etc/cron.d/reload-sysctl.d" do
+      source "reload-sysctl-d.cron"
     end
   end
-
-  template "/etc/logrotate.d/chef" do
-    source "logrotate.erb"
-    owner "root"
-    group "root"
-    mode "0644"
-    variables(:logfiles => "/var/log/chef/client.log",
-              :postrotate => "bluepill chef-client restart")
-  end
-
-  # Set up some basic log rotation
-  template "/etc/logrotate.d/crowbar-webserver" do
-    source "logrotate.erb"
-    owner "root"
-    group "root"
-    mode "0644"
-    variables(:logfiles => "/opt/dell/crowbar_framework/log/*.log",
-                :action => "create 644 crowbar crowbar",
-              :postrotate => "/usr/bin/killall -USR1 rainbows")
-  end if node[:recipes].include?("crowbar")
-  template "/etc/logrotate.d/node-logs" do
-    source "logrotate.erb"
-    owner "root"
-    group "root"
-    mode "0644"
-    variables(:logfiles => "/var/log/nodes/*.log /var/log/nodes/.log",
-              :postrotate => "/usr/bin/killall -HUP rsyslogd")
-  end if node[:recipes].include?("logging::server")
-  template "/etc/logrotate.d/client-join-logs" do
-    source "logrotate.erb"
-    owner "root"
-    group "root"
-    mode "0644"
-    variables(:logfiles => ["/var/log/crowbar/crowbar_join/*"])
-  end unless node[:recipes].include?("crowbar")
-
-  # Note: if adding another hack here, first check if it's needed on SUSE platform too
 end
 
 def sort_boot_order(bootargs)


### PR DESCRIPTION
Use a cronjob that is only executed after a reboot to apply the settings from
files in /etc/sysctl.d/

This should affect only non Ubuntu platforms. So if testing on Ubuntu you want to make sure that /etc/cron.d/reload-sysctl.d is NOT present after a chef-client run.
