### PR TITLE
Allow using the serial number of a node as an additional matching criteria for the bus_order [1/3]

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -91,10 +91,18 @@ module BarclampLibrary
         answer.map! { |x| x[0] }
       end
 
+      # IMPORTANT: This needs to be kept in sync with the get_bus_order method in
+      # node_object.rb in the Crowbar framework.
       def self.get_bus_order(node)
         bus_order = nil
         node["network"]["interface_map"].each do |data|
-          bus_order = data["bus_order"] if node[:dmi][:system][:product_name] =~ /#{data["pattern"]}/
+          if node[:dmi][:system][:product_name] =~ /#{data["pattern"]}/
+            if data.has_key?("serial_number")
+                bus_order = data["bus_order"] if node[:dmi][:system][:serial_number].strip == data["serial_number"].strip
+            else
+                bus_order = data["bus_order"]
+            end
+          end
           break if bus_order
         end rescue nil
         bus_order


### PR DESCRIPTION
This introduces a new optional attribute "serial_number" in the interface_maps
of the network barclamp (+ the needed change to make use of that in the crowbar
and deployer barclamps) that can be use as additional matching criteria for
defining the interface order for a certain node. (This is helpful e.g. if two
nodes with the same value for "Product Name" need to have different
interface_map defined)

 chef/cookbooks/barclamp/libraries/barclamp_library.rb | 10 +++++++++-
 1 file changed, 9 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: ead8713cdc2ce28d97bab36901b28238e32bb08e

Crowbar-Release: pebbles
