### PR TITLE
Windows Server 2012 / Hyper-V Server 2012 support [7/9]

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -182,9 +182,11 @@ module BarclampLibrary
           found = if_map["#{speeds[x]}#{if_cnt}"] unless found
         }
         case m[1]
-          when '+': (desired..speeds.length).each(&filter)
-          when '-': desired.downto(0,&filter) 
-          when '?':  
+          when '+'
+            (desired..speeds.length).each(&filter)
+          when '-'
+            desired.downto(0,&filter) 
+          when '?'  
             (desired..speeds.length).each(&filter)
             desired.downto(0,&filter) unless found
           else

--- a/chef/cookbooks/crowbar-hacks/recipes/default.rb
+++ b/chef/cookbooks/crowbar-hacks/recipes/default.rb
@@ -18,7 +18,7 @@
 
 states = [ "ready", "readying", "recovering", "applying" ]
 if states.include?(node[:state])
-  if node["platform"] != "suse"
+  if node["platform"] != "suse" and node["platform"] != "windows"
     # Don't waste time with mlocate or updatedb
     %w{mlocate mlocate.cron updatedb}.each do |f|
       file "/etc/cron.daily/#{f}" do
@@ -85,7 +85,7 @@ def sort_boot_order(bootargs)
 end
 
 # This should really be its own recipe, but...
-if File.exists?("/sys/firmware/efi")
+if node["platform"] != "windows" and File.exists?("/sys/firmware/efi")
   bootargs = Mash.new
   bootargs["Entries"] = Array.new
   IO.popen("efibootmgr -v") do |p|

--- a/chef/cookbooks/ohai/attributes/default.rb
+++ b/chef/cookbooks/ohai/attributes/default.rb
@@ -19,7 +19,7 @@
 
 # FHS location would be /var/lib/chef/ohai_plugins or similar.
 if node[:platform]=="windows"
- default[:ohai][:plugin_path] = "c:/opscode/chef/embeded/lib/ruby/gems/1.9.1/gems/ohai-6.16.0/lib/ohai/plugins"
+ default[:ohai][:plugin_path] = "c:/opscode/chef/embedded/lib/ruby/gems/1.9.1/gems/ohai-6.16.0/lib/ohai/plugins"
 else
   default[:ohai][:plugin_path] = "/etc/chef/ohai_plugins"
 end

--- a/chef/cookbooks/ohai/attributes/default.rb
+++ b/chef/cookbooks/ohai/attributes/default.rb
@@ -18,4 +18,9 @@
 #
 
 # FHS location would be /var/lib/chef/ohai_plugins or similar.
-default[:ohai][:plugin_path] = "/etc/chef/ohai_plugins"
+if node[:platform]=="windows"
+ default[:ohai][:plugin_path] = "c:/opscode/chef/embeded/lib/ruby/gems/1.9.1/gems/ohai-6.16.0/lib/ohai/plugins"
+else
+  default[:ohai][:plugin_path] = "/etc/chef/ohai_plugins"
+end
+

--- a/chef/cookbooks/ohai/recipes/default.rb
+++ b/chef/cookbooks/ohai/recipes/default.rb
@@ -21,19 +21,23 @@ Ohai::Config[:plugin_path] << node.ohai.plugin_path
 Chef::Log.info("ohai plugins will be at: #{node.ohai.plugin_path}")
 
 # Make secure execution location for ohai
-d = directory "/var/run/ohai" do
-  owner 'root'
-  group 'root'
-  mode 0700
-  recursive true
-  action :nothing
+unless node[:platform] == "windows"
+  d = directory "/var/run/ohai" do
+    owner 'root'
+    group 'root'
+    mode 0700
+    recursive true
+    action :nothing
+  end
+  d.run_action(:create)
 end
-d.run_action(:create)
 
 d = directory node.ohai.plugin_path do
-  owner 'root'
-  group 'root'
-  mode 0755
+  unless node[:platform] == "windows"
+    owner 'root'
+    group 'root'
+    mode 0755
+  end
   recursive true
   action :nothing
 end
@@ -41,9 +45,11 @@ d.run_action(:create)
 
 rd = remote_directory node.ohai.plugin_path do
   source 'plugins'
-  owner 'root'
-  group 'root'
-  mode 0755
+  unless node[:platform] == "windows"
+    owner 'root'
+    group 'root'
+    mode 0755
+  end
   action :nothing
 end
 rd.run_action(:create)

--- a/chef/cookbooks/repos/recipes/default.rb
+++ b/chef/cookbooks/repos/recipes/default.rb
@@ -80,7 +80,7 @@ if provisioner and states.include?(node[:state])
     end
   end
 
-  if node["platform"] != "suse"
+  if node["platform"] != "suse" and node["platform"] != "windows"
     template "/etc/gemrc" do
       variables(:admin_ip => address, :web_port => web_port)
       mode "0644"


### PR DESCRIPTION
## Windows integration required patches in the following areas:
- Ruby 1.9 compatibility as the Windows Chef client is based on Ruby 1.9
- Provisioner barclamp updated for supporting multiple operating systems
- Provisioner barclamp updated for generating Windows unattended.xml files
- TFTP server configuration updated for Windows support
- Crowbar barclamp web UI updated for multiple operating systems support
- NTP support for Windows
- Filters for Linux specific settings on Windows
## Limitations:
- Single Windows image supported. This is due to limitations on the way Windows
  pulls components via TFTP during PXE boot. This issue can be solved in various ways
  that require additional external dependencies that need to be discussed.
- No Nagios and Ganglia clients on Windows
- No IPMI support on Windows
- Windows Administrator password is currently provided in clear text. Needs to be 
  replaced with hash generated by Windows Assesment and Deployment Kit (ADK).
## Additional requirements:
- A Windows image is required to generate the WinPE image used during PXE boot.
  For licensing reasons the image has to be generated by the user/deployer. Scripts
  to automate the instalation of the ADK and the generation of the image are available
  here: http://github.com/adk-tools
  
  .../barclamp/libraries/barclamp_library.rb         |    8 +++--
  chef/cookbooks/crowbar-hacks/recipes/default.rb    |    4 +--
  chef/cookbooks/ohai/attributes/default.rb          |    7 ++++-
  chef/cookbooks/ohai/recipes/default.rb             |   32 ++++++++++++--------
  chef/cookbooks/repos/recipes/default.rb            |    2 +-
  5 files changed, 33 insertions(+), 20 deletions(-)

Crowbar-Pull-ID: 58a2078e8676eb14d4439f36e1ad3e1385f0a21b

Crowbar-Release: pebbles
