### PR TITLE
Make jigs even more late-bound. [5/5]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -26,12 +26,13 @@ crowbar:
   layout: 2.0
   order: 10
 
-jigs:
-  - name: chef
-    roles:
-      - name: bmc-nat-client
-      - name: bmc-nat-router
-      - name: deployer-client
+roles:
+  - name: bmc-nat-client
+    jig: chef
+  - name: bmc-nat-router
+    jig: chef
+  - name: deployer-client
+    jig: chef
 
 debs:
   build_pkgs:


### PR DESCRIPTION
This pull request series makes jigs even more late bound, and reworks
how roles are defined and loaded from crowbar.yml to make it a
seperate section from the to-be-written jigs section, as the jigs
section should concern itself with declaring what (if any) jigs a
barclamp provides.

 crowbar.yml |   13 +++++++------
 1 file changed, 7 insertions(+), 6 deletions(-)

Crowbar-Pull-ID: b068d7f10391d12115dc134ecb5708d4b046de93

Crowbar-Release: development
