### PR TITLE
Account for OVS-created phantom devices in bridge-finding code. [1/1]

### DIFF
--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -588,8 +588,12 @@ class ::Nic
   # Base class for a bridge.  We handle most bridge manipulation via brctl.
   class ::Nic::Bridge < ::Nic
     def slaves
-      ::Dir.entries("#{@nicdir}/brif").reject do |i|
-        i == '.' || i == '..'
+      ::Dir.entries("#{@nicdir}/brif").select do |i|
+        link = File.join("#{@nicdir}/brif",i)
+        # OVS likes to create links to devices that do not really exist.
+        # Skip them.
+        File.symlink?(link) &&
+          File.exists?(File.readlink(link))
       end.map{|i| ::Nic.new(i)}
     end
 


### PR DESCRIPTION
After Quantum has been configured to use OVS and installed on a node,
it creates several OVS switches to control traffic flow to the Nova
VMs.  OVS bridges tend to have one or more phantom devices that are
not reflected in sysfs and cannot be managed outside of the OVS
toolset.

This winds up causing chef-client runs failing on these nodes when the
network recipe discovers the network config on the system:

```
[Thu, 18 Jul 2013 15:18:34 +0000] INFO: Using vlan bond0.300 for network public

================================================================================
Recipe Compile Error in /var/cache/chef/cookbooks/network/recipes/default.rb
================================================================================

ArgumentError
-------------
qr-a3a14629-d3 does not exist!  Did you mean Nic.create?

Cookbook Trace:
---------------
  /var/cache/chef/cookbooks/barclamp/libraries/nic.rb:438:in new'
  /var/cache/chef/cookbooks/barclamp/libraries/nic.rb:593:in slaves'
  /var/cache/chef/cookbooks/barclamp/libraries/nic.rb:591:in map'
  /var/cache/chef/cookbooks/barclamp/libraries/nic.rb:591:in slaves'
  /var/cache/chef/cookbooks/barclamp/libraries/nic.rb:374:in dependents'
  /var/cache/chef/cookbooks/barclamp/libraries/nic.rb:59:in nics'
  /var/cache/chef/cookbooks/barclamp/libraries/nic.rb:58:in each'
  /var/cache/chef/cookbooks/barclamp/libraries/nic.rb:58:in nics'
  /var/cache/chef/cookbooks/network/recipes/default.rb:145:in from_file'
  /var/cache/chef/cookbooks/network/recipes/default.rb:73:in each'
  /var/cache/chef/cookbooks/network/recipes/default.rb:73:in `from_file'

Relevant File Content:
----------------------
/var/cache/chef/cookbooks/barclamp/libraries/nic.rb:

431:      elsif bond?(nic)
432:        o = ::Nic::Bond.allocate
433:        logstr = "Returning new bond interface"
434:      elsif exists?(nic)
435:        o = ::Nic.allocate
436:        logstr = "Returning new interface"
437:      else
438>>       raise ArgumentError.new("#{nic} does not exist!  Did you mean Nic.create?")
439:      end
440:      o.send(:initialize, nic)
441:      Chef::Log.info("#{logstr} #{o.inspect}")
442:      @@interfaces[nic] = o
443:      return o
444:    end
445:  
446:    # Base class for a bond.
447:    # We handle all bond manipulation via sysfs for maximum flexibility.

[Thu, 18 Jul 2013 15:18:34 +0000] ERROR: Running exception handlers
```

The fix is to ignore bridge slaves in sysfs that do not point to real
devices, and this pull request implements that logic.

 chef/cookbooks/barclamp/libraries/nic.rb |    8 ++++++--
 1 file changed, 6 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: 73e1d1fa0c7ff0e378e90230a8191739a1c854f6

Crowbar-Release: mesa-1.6
