### PR TITLE
Rework how we setup logging for Crowbar [2/3]

### DIFF
--- a/chef/cookbooks/crowbar-hacks/recipes/default.rb
+++ b/chef/cookbooks/crowbar-hacks/recipes/default.rb
@@ -41,7 +41,7 @@ if states.include?(node[:state])
       owner "root"
       group "root"
       mode "0644"
-      variables(:logfiles => "/opt/dell/crowbar_framework/log/*.log /opt/dell/crowbar_framework/log/*.stdout /opt/dell/crowbar_framework/log/*.stderr",
+      variables(:logfiles => "/var/log/crowbar/*.log /var/log/crowbar/*.out /var/log/crowbar/chef-client/*.log",
                   :action => "create 644 crowbar crowbar",
                 :postrotate => "/usr/bin/killall -USR1 rainbows")
     end if node[:recipes].include?("crowbar")


### PR DESCRIPTION
There are two main changes:
- instead of putting stdout/stderr in production.log, we put them in
  production.stdout and production.stderr.
- we really use production.log to log things, instead of using syslog
  which loses the formatting and spams /var/log/messages.

The rationale for using syslog was "distributed setups", but since we
put the logs of chef-client runs in /opt/dell/crowbar_framework anyway,
I don't think this rationale stands.

Crowbar-Pull-ID: b381b3bca3dd6482b6c462570095828859ba5a08

Crowbar-Release: pebbles
