### PR TITLE
Fix bond naming

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -234,7 +234,7 @@ module BarclampLibrary
           @vlan = data["vlan"]
           @use_vlan = data["use_vlan"]
           @conduit = data["conduit"]
-          @interface = rintf
+          @interface = data["use_vlan"] ? "#{rintf}.#{data["vlan"]}" : rintf
           @interface_list = interface_list
           @add_bridge = data["add_bridge"]
         end


### PR DESCRIPTION
This pull request depends on https://github.com/crowbar/barclamp-network/pull/203. Please merge crowbar/barclamp-network#203 before this one.
