### PR TITLE
Make sure that Nic::Bridge.slaves is reading the full symlink. [1/1]

### DIFF
--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -592,8 +592,7 @@ class ::Nic
         link = File.join("#{@nicdir}/brif",i)
         # OVS likes to create links to devices that do not really exist.
         # Skip them.
-        File.symlink?(link) &&
-          File.exists?(File.readlink(link))
+        File.symlink?(link) && File.exists?(File.join(link,File.readlink(link)))
       end.map{|i| ::Nic.new(i)}
     end
 


### PR DESCRIPTION
Victor fix for nic to be fixed in bridge group.

 chef/cookbooks/barclamp/libraries/nic.rb |    3 +--
 1 file changed, 1 insertion(+), 2 deletions(-)

Crowbar-Pull-ID: a2ef5ca18d4503b38c6be7aec0f9f476cc5621dc

Crowbar-Release: mesa-1.6.1/openstack-build
