### PR TITLE
CB 2.0 can bootstrap an admin node to having a provisioner [7/7]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -35,6 +35,7 @@ roles:
     jig: chef
     flags:
       - discovery
+      - bootstrap
 
 debs:
   build_pkgs:


### PR DESCRIPTION
To try it out:
- Build an ISO
- Install the admin node.
- Install crowbar with /opt/dell/bin/install-crowbar your.test.name
- Wait for the install to "finish"
- Check out the functional UI @ 192.168.124.10:3000
- Run these soon-to-be-unneeded-commands:
- su - crowbar
- cd /opt/dell/crowbar_framework
- bundle exec script/rails c production
- Node.make_admin!
- NodeRole.converge!
- Watch the node roles converge in the UI.
- Marvel at how much more granular it is.
- Gaze in awe at the detailed per-node display of inbound and
  outbound data.
- Tremble at a UI that displays what exactly happened to make a node
  role do its thing.
- Profit.
  
  crowbar.yml |    1 +
  1 file changed, 1 insertion(+)

Crowbar-Pull-ID: c3b0cb7e352feeff6881ccd3369d63b7170a505b

Crowbar-Release: development
