### PR TITLE
Account for OVS-created phantom devices in bridge-finding code.

### DIFF
--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -609,8 +609,12 @@ class ::Nic
   # Base class for a bridge.  We handle most bridge manipulation via brctl.
   class ::Nic::Bridge < ::Nic
     def slaves
-      ::Dir.entries("#{@nicdir}/brif").reject do |i|
-        i == '.' || i == '..'
+      ::Dir.entries("#{@nicdir}/brif").select do |i|
+        link = File.join("#{@nicdir}/brif",i)
+        # OVS likes to create links to devices that do not really exist.
+        # Skip them.
+        File.symlink?(link) &&
+          File.exists?(File.readlink(link))
       end.map{|i| ::Nic.new(i)}
     end
 


### PR DESCRIPTION
cherry picked from https://github.com/crowbar/barclamp-deployer/pull/141
