### PR TITLE
Make sure that Nic::Bridge.slaves is reading the full symlink( merge from mesa to roxy) [1/1]

### DIFF
--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -613,8 +613,7 @@ class ::Nic
         link = File.join("#{@nicdir}/brif",i)
         # OVS likes to create links to devices that do not really exist.
         # Skip them.
-        File.symlink?(link) &&
-          File.exists?(File.readlink(link))
+        File.symlink?(link) && File.exists?(File.join(link,File.readlink(link)))
       end.map{|i| ::Nic.new(i)}
     end
 


### PR DESCRIPTION
ke sure that Nic::Bridge.slaves is reading the full symlink( merge from mesa to roxy )

 chef/cookbooks/barclamp/libraries/nic.rb |    3 +--
 1 file changed, 1 insertion(+), 2 deletions(-)

Crowbar-Pull-ID: bdb979b6d06e29988c20e23b0517e8e953e829c5

Crowbar-Release: roxy
