### PR TITLE
Changed the regex search pattern in bc-template-deployer.json [1/1]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-deployer.json
+++ b/chef/data_bags/crowbar/bc-template-deployer.json
@@ -6,7 +6,7 @@
       "use_allocate": true,
       "bios_map": [
 	{ "pattern": ".*-datanode", "bios_set": "Hadoop", "raid_set": "JBODOnly" },
-	{ "pattern": "(hadoop|clouderamanager)-.*", "bios_set": "HadoopInfra", "raid_set": "SingleRaid10" },
+	{ "pattern": "(hadoop|hadoop_infrastructure)-.*", "bios_set": "HadoopInfra", "raid_set": "SingleRaid10" },
         { "pattern": "nova-.*", "bios_set": "Virtualization", "raid_set": "SingleRaid10" },
         { "pattern": "swift-.*", "bios_set": "Storage", "raid_set": "JBODOnly" },
         { "pattern": ".*", "bios_set": "Virtualization", "raid_set": "SingleRaid10" }


### PR DESCRIPTION
Changed the regex search pattern in bc-template-deployer.json in order to accommodate
the new hadoop barclamp split out  - %s/clouderamanager/hadoop_infrastructure/g.

 chef/data_bags/crowbar/bc-template-deployer.json |    2 +-
 1 files changed, 1 insertions(+), 1 deletions(-)

Crowbar-Pull-ID: cd73a9905c7f994be95c1b42c1045afc50ac68ee

Crowbar-Release: roxy
