### PR TITLE
Fix finding bridge slaves

### DIFF
--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -614,7 +614,7 @@ class ::Nic
         # OVS likes to create links to devices that do not really exist.
         # Skip them.
         File.symlink?(link) &&
-          File.exists?(File.readlink(link))
+          File.exists?(File.expand_path(File.readlink(link), "#{@nicdir}/brif"))
       end.map{|i| ::Nic.new(i)}
     end
 


### PR DESCRIPTION
Commit f2f444ab broke the detection of bridge slaves: it tried to check
if symlinks were pointing to existing files, but was not expanding the
paths to absolute paths. So the tests were failing because they were
done on relative paths...

Note that we're using File.expand_path (and not File.realpath) to keep
compatibility with ruby 1.8.x.
