### PR TITLE
Fix finding bridge slaves

### DIFF
--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -613,7 +613,8 @@ class ::Nic
         link = File.join("#{@nicdir}/brif",i)
         # OVS likes to create links to devices that do not really exist.
         # Skip them.
-        File.symlink?(link) && File.exists?(File.join(link,File.readlink(link)))
+        File.symlink?(link) &&
+          File.exists?(File.expand_path(File.readlink(link), "#{@nicdir}/brif"))
       end.map{|i| ::Nic.new(i)}
     end
 


### PR DESCRIPTION
Commit f2f444ab broke the detection of bridge slaves: it tried to check
if symlinks were pointing to existing files, but was not expanding the
paths to absolute paths. So the tests were failing because they were
done on relative paths...

Commit cb6c1b84 attempted to fix that, but the fix wasn't fully correct
either as far as I can tell: it does
File.join("/sys/class/net/foo/brif/eth0.300", "../../eth0.300/brport")
instead of
File.join("/sys/class/net/foo/brif", "../../eth0.300/brport")

Note that we're using File.expand_path (and not File.realpath) to keep
compatibility with ruby 1.8.x.
