### PR TITLE
Allow the provisioner to handle building Sledgehammer. [2/3]

### DIFF
--- a/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
@@ -20,9 +20,10 @@
 Gem.clear_paths
 outer_paths=%x{gem env gempath}.split(':')
 outer_paths.each do |p|
-  next if Gem.path.member?(p)
-  Gem.paths.path << p
+  next if Gem.path.member?(p.strip)
+  Gem.paths.path << p.strip
 end
+Chef::Log.debug("Gem path set to #{Gem.paths.path}")
 
 
 require 'etc'
@@ -126,10 +127,10 @@ def get_supported_speeds(interface)
     rv.data = ifreq.unpack("a16p")[1]
 
     speeds = []
-    speeds << "10m" if (rv.supported & ((1<<0)|(1<<1))) != 0
-    speeds << "100m" if (rv.supported & ((1<<2)|(1<<3))) != 0
-    speeds << "1g" if (rv.supported & ((1<<4)|(1<<5))) != 0
-    speeds << "10g" if (rv.supported & ((0xf<<17)|(1<<12))) != 0
+    speeds << "10m" if (rv.supported & ((1 << 0)|(1 << 1))) != 0
+    speeds << "100m" if (rv.supported & ((1 << 2)|(1 << 3))) != 0
+    speeds << "1g" if (rv.supported & ((1 << 4)|(1 << 5))) != 0
+    speeds << "10g" if (rv.supported & ((0xf << 17)|(1 << 12))) != 0
     speeds
   rescue Exception => e
     puts "Failed to get ioctl for speed: #{e.message}"


### PR DESCRIPTION
This pull request series allows the Crowbar build system to let the
provisioner handle building Sledgehammer instead of forcing the
top-level build machinery to have sole responsibility for building
it.  This makes it possible for releases to have their own versions of
Sledgehammer instead of forcing all releases to assume they are
talking to the same Sledgehammer image.

The first use of this functionality is also included in this pull
request, which changes how Sledgehammer operates for CB 2.0:
- Remove some unneeded bundled packages (Chef and friends,
  specifically)
- Remove our reliance on NFS.
- Change the default password for the root user on Sledgehammer to "crowbar"
  
  chef/cookbooks/ohai/files/default/plugins/crowbar.rb | 13 +++++++------
  1 file changed, 7 insertions(+), 6 deletions(-)

Crowbar-Pull-ID: 1ec7113e8c740a01d2d6b4b05f18567143c353b1

Crowbar-Release: development
