### PR TITLE
Replace rm known_hosts with rm -f

### DIFF
--- a/crowbar_framework/app/models/deployer_service.rb
+++ b/crowbar_framework/app/models/deployer_service.rb
@@ -67,7 +67,7 @@ class DeployerService < ServiceObject
 
       # Make sure that the node can be accessed by knife ssh or ssh
       if ["reset","reinstall","update","delete"].member?(state)
-        system("sudo rm /root/.ssh/known_hosts")
+        system("sudo rm -f /root/.ssh/known_hosts")
       end
     end
 


### PR DESCRIPTION
Pretty small fix, get rid of `rm: cannot remove /root/.ssh/known_hosts: No such file or directory` within rails server output.
