### PR TITLE
Add a basic disk reservation system to CB 2.0, and fix up the Ceph barclamp to use it. [3/3]

### DIFF
--- a/chef/cookbooks/barclamp/libraries/reservations.rb
+++ b/chef/cookbooks/barclamp/libraries/reservations.rb
@@ -1,0 +1,86 @@
+class Chef
+  class Node
+    def disks
+      res = Mash.new
+      self[:crowbar_ohai][:disks][:order].each do |d|
+        res[d] = self[:crowbar_ohai][:disks][d]
+      end
+      res
+    end
+
+    def reserve_disk(name,owner)
+      self.normal[:crowbar_wall] ||= Mash.new
+      self.normal[:crowbar_wall][:reservations] ||= Mash.new
+      self.normal[:crowbar_wall][:reservations][:disks] ||= Mash.new
+      name = name.split("/")[-1]
+      natural_name = if self[:crowbar_ohai][:disks][name]
+                       name
+                     elsif self[:crowbar_ohai][:disks][:by_id][name]
+                       self[:crowbar_ohai][:disks][:by_id][name]
+                     elsif self[:crowbar_ohai][:disks][:by_path][name]
+                       self[:crowbar_ohai][:disks][:by_path][name]
+                     else
+                       raise "Cannot find natural name for disk #{name}"
+                     end
+      disk = self[:crowbar_ohai][:disks][natural_name]
+      unless disk[:available]
+        Chef::Log.error("Disk #{name} is not available to be reserved!")
+        return false
+      end
+      unique_name = disk["preferred_device_name"].split("/")[-1]
+      return true if self[:crowbar_wall][:reservations][:disks][unique_name] == owner
+      if self[:crowbar_wall][:reservations][:disks][unique_name]
+        Chef::Log.error("Disk #{name} is already claimed by #{self[:crowbar_wall][:reservations][:disks][unique_name]}")
+        return false
+      end
+      self.normal[:crowbar_wall][:reservations][:disks][unique_name] = owner
+      true
+    end
+
+    def reserved_disks
+      res = Mash.new
+      (self.normal[:crowbar_wall][:reservations][:disks] rescue {}).each do |k,v|
+        res[v] ||= Array.new
+        res[v] << k
+      end
+      res
+    end
+
+    def reserved_disk?(name)
+      name = name.split("/")[-1]
+      natural_name = if self[:crowbar_ohai][:disks][name]
+                       name
+                     elsif self[:crowbar_ohai][:disks][:by_id][name]
+                       self[:crowbar_ohai][:disks][:by_id][name]
+                     elsif self[:crowbar_ohai][:disks][:by_path][name]
+                       self[:crowbar_ohai][:disks][:by_path][name]
+                     else
+                       raise "Cannot find natural name for disk #{name}"
+                     end
+      disk = self[:crowbar_ohai][:disks][natural_name]
+      unique_name = disk["preferred_device_name"].split("/")[-1]
+      self[:crowbar_wall][:reservations][:disks][unique_name] rescue nil
+    end
+
+    def release_disk(name,owner)
+      name = name.split("/")[-1]
+      natural_name = if self[:crowbar_ohai][:disks][name]
+                       name
+                     elsif self[:crowbar_ohai][:disks][:by_id][name]
+                       self[:crowbar_ohai][:disks][:by_id][name]
+                     elsif self[:crowbar_ohai][:disks][:by_path][name]
+                       self[:crowbar_ohai][:disks][:by_path][name]
+                     else
+                       raise "Cannot find natural name for disk #{name}"
+                     end
+      disk = self[:crowbar_ohai][:disks][natural_name]
+      unique_name = disk["preferred_device_name"].split("/")[-1]
+      unless self[:crowbar_wall][:reservations][:disks][unique_name] == owner
+        Chef::Log.error("Cannot release disk #{name}, it is not owned by #{owner}")
+        return false
+      end
+      self.normal[:crowbar_wall][:reservations][:disks] = self[:crowbar_wall][:reservations][:disks].reject{|k,v|k == unique_name}
+      true
+    end
+  end
+end

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -40,6 +40,12 @@ attribs:
   - name: disks
     description: "The local raw disks that Crowbar has detected"
     map: 'ohai/crowbar_ohai/disks'
+  - name: all_reservations
+    description: "All reservations against resources on this node"
+    map: 'reservations'
+  - name: disk_reservations
+    description: "All disk reservations against this node."
+    map: 'reservations/disks'
 
 debs:
   build_pkgs:


### PR DESCRIPTION
This adds a basic framework to allow Chef recipes to reserve disks on
nodes, along with core Crowbar support for making sure those
reservations are known to all noderole runs.

 chef/cookbooks/barclamp/libraries/reservations.rb | 86 +++++++++++++++++++++++
 crowbar.yml                                       |  6 ++
 2 files changed, 92 insertions(+)

Crowbar-Pull-ID: 49d97fa8999a043f27517044314ccec9d4ee9065

Crowbar-Release: development
