### PR TITLE
Fixes for CES 1499 [2/2]

### DIFF
--- a/updates/wsman/lib/wsman.rb
+++ b/updates/wsman/lib/wsman.rb
@@ -301,8 +301,14 @@ class Crowbar
 
   def get_job_selector(instHash)
     puts "Parsing job selector string"
-    selectorStr = instHash["ReferenceParameters"]["ResourceURI"] + "?"
-    selectorSet = instHash["ReferenceParameters"]["SelectorSet"]
+    testFor12G  = instHash["EndpointReference"]
+    if (testFor12G.nil?)
+      selectorStr = instHash["ReferenceParameters"]["ResourceURI"] + "?"
+      selectorSet = instHash["ReferenceParameters"]["SelectorSet"]
+    else
+      selectorStr = instHash["EndpointReference"]["ReferenceParameters"]["ResourceURI"] + "?"
+      selectorSet = instHash["EndpointReference"]["ReferenceParameters"]["SelectorSet"]
+    end
     selectorSet["Selector"].each do |selector|
       selectorStr += selector["Name"] + "=" + selector["content"] unless selector["Name"] == "__cimnamespace"
     end


### PR DESCRIPTION
Fixed enabling transition of boot mode when there are no boot sources to be
enabled or re-ordered

Fixed parsing of job information after creating targeted config job in set-boot
recipe

Polling job for completion before passing on to bios recipes to ensure reboot

 updates/wsman/lib/wsman.rb |   14 ++++++++++----
 1 file changed, 10 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: 9dddf1b9efb69db3a1c15a80d4749bd036bb6328

Crowbar-Release: hadoop-2.4
