### PR TITLE
Refresh source interface before usurping routes and addresses

### DIFF
--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -336,6 +336,7 @@ class ::Nic
   def usurp(victim)
     self.up
     victim = ::Nic.coerce(victim)
+    victim.refresh
     new_routes = (victim.routes - routes)
     new_addrs = victim.addresses
     return [ [], [] ] if new_routes.empty? && new_addrs.empty?


### PR DESCRIPTION
The configuration of the source interface might have change since the start of
the chef-client run. Specifically when running in HA mode, pacemaker might have
assigned addtional virtual IP Addressed to the interface. If we don't refresh here
those IPs get lost.
