### PR TITLE
Configuring python package sources along with other repositories.

### DIFF
--- a/chef/cookbooks/repos/recipes/default.rb
+++ b/chef/cookbooks/repos/recipes/default.rb
@@ -86,4 +86,35 @@ if provisioner and states.include?(node[:state])
       mode "0644"
     end
   end
+
+  # Configuring pip package sources
+
+  directory "/root/.pip" do
+    owner "root"
+    group "root"
+    mode 00644
+    action :create
+  end
+
+  template "/root/.pip/pip.conf" do
+    source "pyconf.erb"
+    mode 0644
+    variables(
+      :pip_conf => true,
+      :proxy_addr => provisioner[:fqdn],
+      :proxy_port => provisioner[:provisioner][:web_port]
+    )
+  end
+
+  template "/root/.pydistutils.cfg" do
+    source "pyconf.erb"
+    mode 0644
+    variables(
+      :pydistutils => true,
+      :proxy_addr => provisioner[:fqdn],
+      :proxy_port => provisioner[:provisioner][:web_port]
+    )
+  end
+
+
 end

--- a/chef/cookbooks/repos/templates/default/pyconf.erb
+++ b/chef/cookbooks/repos/templates/default/pyconf.erb
@@ -1,0 +1,8 @@
+<% if @pydistutils -%>
+[easy_install]
+index_url = http://<%= @proxy_addr %>:<%= @proxy_port %>/files/pip_cache/simple/
+<% end -%>
+<% if @pip_conf -%>
+[global]
+index_url = http://<%= @proxy_addr %>:<%= @proxy_port %>/files/pip_cache/simple/
+<% end -%>


### PR DESCRIPTION
Allows to configure package sources for pip and pydistutils automatically on deployment stage and prevents configuration options to be ignored during  recursive dependencies installation.
