### PR TITLE
Small cleanup to avoid some uneeded save calls on the roles/nodes

### DIFF
--- a/crowbar_framework/app/models/deployer_service.rb
+++ b/crowbar_framework/app/models/deployer_service.rb
@@ -155,9 +155,8 @@ class DeployerService < ServiceObject
       node.crowbar["crowbar"]["usedhcp"] = true
 
       role = RoleObject.find_role_by_name "deployer-config-#{inst}"
-      if role.default_attributes["deployer"]["use_allocate"] and !node.admin?
-        node.allocated = false 
-      else
+      unless role.default_attributes["deployer"]["use_allocate"] and !node.admin?
+        @logger.debug("Automatically allocating node #{node.name}")
         node.allocated = true
       end
 


### PR DESCRIPTION
'allocated' is set to 'false' by default already during discovery
