### PR TITLE
Read /sys/block/<device>/queue/rotational, so we can check for SSD disks

### DIFF
--- a/chef/cookbooks/ohai/files/default/plugins/linux/block_device_extended.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/linux/block_device_extended.rb
@@ -19,6 +19,13 @@ if File.exists?("/sys/block")
         File.open("/sys/block/#{dir}/device/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
       end
     end
+
+    %w{rotational}.each do |check|
+      if File.exists?("/sys/block/#{dir}/queue/#{check}")
+        File.open("/sys/block/#{dir}/queue/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
+      end
+    end
+
   end
 
   disk_path = Pathname.new "/dev/disk"


### PR DESCRIPTION
(SSD device has rotational == 0)

Alternatively, we could create "queue" submap, instead of putting rotational directly into the main map.
