### PR TITLE
Add applied attribute

### DIFF
--- a/chef/data_bags/crowbar/bc-template-deployer.json
+++ b/chef/data_bags/crowbar/bc-template-deployer.json
@@ -17,6 +17,7 @@
   "deployment": {
     "deployer": {
       "crowbar-revision": 0,
+      "crowbar-applied": false,
       "element_states": {
         "deployer-client": [ "all" ]
       },

--- a/chef/data_bags/crowbar/bc-template-deployer.schema
+++ b/chef/data_bags/crowbar/bc-template-deployer.schema
@@ -47,6 +47,7 @@
           "mapping": {
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
+            "crowbar-applied": { "type": "bool" },
             "crowbar-status": { "type": "str" },
             "crowbar-failed": { "type": "str" },
             "crowbar-queued": { "type": "bool" },

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -27,7 +27,7 @@ crowbar:
   order: 10
   run_order: 10
   chef_order: 10
-  proposal_schema_version: 2
+  proposal_schema_version: 3
 
 debs:
   build_pkgs:


### PR DESCRIPTION
We add a crowbar applied attribute to mark the proposal as applied after the chef run. This allows the UI to show that the current form of the proposal has been 'applied' successfully (i.e. chef-client completed the run w/ success) and that the proposal was then not modified.

The second patch adds the proposal_schema_revision, so we can add the attribute to schema for ('3rd party') barclamps that currently do not have it.

Refs: https://github.com/crowbar/crowbar/pull/2044 (which adds this attribute to barclamps which lack it), https://github.com/crowbar/barclamp-crowbar/pull/1068 (which marks the proposals as applied) and https://bugzilla.novell.com/show_bug.cgi?id=877486
