### PR TITLE
Fixed UEFI config (bnc#865871)

### DIFF
--- a/chef/cookbooks/crowbar-hacks/recipes/default.rb
+++ b/chef/cookbooks/crowbar-hacks/recipes/default.rb
@@ -100,10 +100,10 @@ if node["platform"] != "windows" and File.exists?("/sys/firmware/efi")
       when k =~ /^Boot[0-9a-fA-F]{1,4}/
         desc,device = v.split("\t")
         res = {}
-        res["Description"] = desc.dup.freeze
-        res["Device"] = device.dup.freeze
+        res["Description"] = desc
+        res["Device"] = device
         res["Active"] = (k[-1,1] == '*')
-        bootargs["Entries"][k.match(/^Boot([0-9a-fA-F]+)/)[1].hex] = res.dup.freeze
+        bootargs["Entries"][k.match(/^Boot([0-9a-fA-F]+)/)[1].hex] = res
       else next
       end
     end


### PR DESCRIPTION
This is a decent backport of the fix against next crowbar version. It
already have been better integrated with
https://github.com/crowbar/barclamp-deployer/pull/216 and
https://github.com/crowbar/barclamp-provisioner/pull/323.

This fixes https://bugzilla.novell.com/show_bug.cgi?id=865871 for roxy
release.
