### PR TITLE
Install right version of cstruct rubygem before calling ohai

### DIFF
--- a/chef/cookbooks/ohai/recipes/default.rb
+++ b/chef/cookbooks/ohai/recipes/default.rb
@@ -59,7 +59,15 @@ rd.run_action(:create)
 # install/check packages there)
 states = [ "ready", "readying", "recovering", "applying" ]
 if states.include?(node[:state])
-  package("ruby#{node["languages"]["ruby"]["version"].to_f}-rubygem-cstruct").run_action(:install)
+  # During the upgrade process (stoney -> tex, old ruby&rails -> tex
+  # ruby&rails), we need to run the new cookbook with the old ruby&rails once,
+  # so we need to support this
+  if node["languages"]["ruby"]["version"].to_f == 1.8
+    pkg = "rubygem-cstruct"
+  else
+    pkg = "ruby#{node["languages"]["ruby"]["version"].to_f}-rubygem-cstruct"
+  end
+  package(pkg).run_action(:install)
 
   begin
     require 'cstruct'


### PR DESCRIPTION
This ensures that the cstruct rubygem is installed, even after we
upgraded to a new version of ruby.

Note that this should actually help get rid of the hard-coding of this
gem in the provisioner barclamp.