### PR TITLE
Do not rely on DMI information being available

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -349,7 +349,8 @@ module BarclampLibrary
               disk_lookups = []
             end
           end
-          unless @node[:dmi][:system][:product_name] =~ /VirtualBox/i
+          hardware = @node[:dmi][:system][:product_name] rescue "unknown"
+          unless hardware =~ /VirtualBox/i
             disk_lookups.unshift "by-id"
           end
           disk_lookups.each do |n|


### PR DESCRIPTION
When the admin node is installed virtual or on very new
hardware, dmidecode is not available so the dmi ohai tree
is empty.