### PR TITLE
Fix one more case where DMI information is accessed

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -78,7 +78,8 @@ module BarclampLibrary
       def self.get_bus_order(node)
         bus_order = nil
         node["network"]["interface_map"].each do |data|
-          if node[:dmi][:system][:product_name] =~ /#{data["pattern"]}/
+          hardware = node[:dmi][:system][:product_name] rescue "unknown"
+          if hardware =~ /#{data["pattern"]}/
             if data.has_key?("serial_number")
                 bus_order = data["bus_order"] if node[:dmi][:system][:serial_number].strip == data["serial_number"].strip
             else


### PR DESCRIPTION
DMI System information is missing if the hardware is too
new or virtualized, so don't depend on it.