### PR TITLE
Fix broken switch detection in ohai

### DIFF
--- a/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
@@ -208,9 +208,9 @@ networks.each do |network|
   if line =~ /: Unit (\d+) Port (\d+)/
     sw_unit, sw_port = $1, $2
   end
-  if line =~ %r!: (\S+ (\d+)/(\d+))!
+  if line =~ %r!: (\S+ (\d+)/\d+/(\d+))!
     sw_port_name, foo, bar = $1, $2, $3
-  elsif line =~ %r!: (Gi(\d+)/(\d+))!
+  elsif line =~ %r!: (Gi(\d+)/\d+/(\d+))!
     sw_port_name, foo, bar = $1, $2, $3
   else
     sw_port_name = "#{sw_unit}/0/#{sw_port}"

--- a/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
@@ -209,9 +209,9 @@ networks.each do |network|
     sw_unit, sw_port = $1, $2
   end
   if line =~ %r!: (\S+ (\d+)/(\d+))!
-    sw_port_name, sw_unit, sw_port = $1, $2, $3
+    sw_port_name, foo, bar = $1, $2, $3
   elsif line =~ %r!: (Gi(\d+)/(\d+))!
-    sw_port_name, sw_unit, sw_port = $1, $2, $3
+    sw_port_name, foo, bar = $1, $2, $3
   else
     sw_port_name = "#{sw_unit}/0/#{sw_port}"
   end

--- a/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
@@ -208,10 +208,10 @@ networks.each do |network|
   if line =~ /: Unit (\d+) Port (\d+)/
     sw_unit, sw_port = $1, $2
   end
-  if line =~ %r!: (\S+ (\d+)/\d+/(\d+))!
-    sw_port_name, foo, bar = $1, $2, $3
-  elsif line =~ %r!: (Gi(\d+)/\d+/(\d+))!
-    sw_port_name, foo, bar = $1, $2, $3
+  if line =~ %r!: (\S+ \d+/\d+/\d+)!
+    sw_port_name = $1
+  elsif line =~ %r!: (Gi\d+/\d+/\d+)!
+    sw_port_name = $1
   else
     sw_port_name = "#{sw_unit}/0/#{sw_port}"
   end


### PR DESCRIPTION
The parsing was overriding the values for the switch unit and port that
we already found, and was actually parsing wrong values instead...