### PR TITLE
by default, do not return mounted disks as unclaimed

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -254,8 +254,12 @@ module BarclampLibrary
           node[:block_device].keys.map{|d|Disk.new(node,d)}
         end
 
-        def self.unclaimed(node)
+        def self.unclaimed(node, include_mounted=false)
           all(node).select do |d|
+            unless include_mounted
+              %x{lsblk #{d.name.gsub(/!/, "/")} --noheadings --output MOUNTPOINT | grep -q -v ^$}
+              next if $?.exitstatus == 0
+            end
             d.fixed and not d.claimed?
           end
         end


### PR DESCRIPTION
This could help with some incorrect claiming of disks that are actually in use.

Places that currently rely on returning all unclaimed disks (like https://github.com/crowbar/barclamp-provisioner/blob/master/chef/cookbooks/provisioner/recipes/bootdisk.rb#L5) need to be adapted