### PR TITLE
backport of bnc#945219 workaround

### DIFF
--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -648,17 +648,18 @@ class ::Nic
     end
 
     def add_slave(slave)
-      slave = self.class.coerce(slave)
       unless ::Nic.exists?(slave)
         raise ::ArgumentError.new("#{slave} does not exist, cannot add to bridge#{@nic}")
       end
-      return if slaves.member?(slave)
+      slave = self.class.coerce(slave)
+      return slave if slaves.member?(slave)
       if current_master = slave.master
         current_master.remove_slave(slave)
       end
       slave.up
       usurp(slave)
       ::Kernel.system("brctl addif #{@nic} #{slave}")
+      slave
     end
 
     def remove_slave(slave)
@@ -668,6 +669,7 @@ class ::Nic
       end
       ::Kernel.system("brctl delif #{@nic} #{slave}")
       slave.down
+      slave
     end
 
     def stp
@@ -745,17 +747,18 @@ class ::Nic
     end
 
     def add_slave(slave)
-      slave = self.class.coerce(slave)
       unless ::Nic.exists?(slave)
         raise ::ArgumentError.new("#{slave} does not exist, cannot add to bridge#{@nic}")
       end
-      return if slaves.member?(slave)
+      slave = self.class.coerce(slave)
+      return slave if slaves.member?(slave)
       if current_master = slave.master
         current_master.remove_slave(slave)
       end
       slave.up
       usurp(slave)
       ::Kernel.system("ovs-vsctl add-port #{@nic} #{slave}")
+      slave
     end
 
     def remove_slave(slave)
@@ -765,6 +768,7 @@ class ::Nic
       end
       ::Kernel.system("ovs-vsctl del-port #{@nic} #{slave}")
       slave.down
+      slave
     end
 
     def up

--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -718,6 +718,8 @@ class ::Nic
         ::Kernel.system("modprobe bridge")
       end
       ::Kernel.system("brctl addbr #{nic}")
+      # It might take a little until the sysfs files for the bridge appear
+      # so let's wait for that
       5.times do
         if self.exists?(nic) && self.bridge?(nic)
           iface = ::Nic.new(nic)
@@ -800,6 +802,8 @@ class ::Nic
         raise ::ArgumentError.new("#{nic} already exists.")
       end
       ::Kernel.system("ovs-vsctl add-br #{nic}")
+      # It might take a little until the sysfs files for the bridge appear
+      # so let's wait for that
       5.times do
         if self.exists?(nic) && self.ovs_bridge?(nic)
           iface = ::Nic.new(nic)

--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -781,6 +781,15 @@ class ::Nic
       nil
     end
 
+    def replug(slave)
+      slave = self.class.coerce(slave)
+      unless self.slaves.member?(slave)
+        raise ::ArgumentError.new("#{slave} is not a member of bridge #{@nic}")
+      end
+      ::Kernel.system("ovs-vsctl del-port #{@nic} #{slave}")
+      ::Kernel.system("ovs-vsctl add-port #{@nic} #{slave}")
+    end
+
     def self.create(nic, slaves = [])
       Chef::Log.info("Creating new OVS bridge #{nic}")
       if self.exists?(nic)

--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -374,7 +374,9 @@ class ::Nic
   # Return the bond we are enslaved to, or nil if we are not in a bond.
   def bond_master
     return nil unless File.exists?("#{@nicdir}/master")
-    Nic.new(File.readlink("#{@nicdir}/master").split('/')[-1])
+    master = File.readlink("#{@nicdir}/master").split("/")[-1]
+    return nil unless Nic.bond?(master)
+    Nic.new(master)
   end
 
   # Return the bridge we are enslaved to, or nil if we are not in a bridge.

--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -650,8 +650,8 @@ class ::Nic
       unless ::Nic.exists?(slave)
         raise ::ArgumentError.new("#{slave} does not exist, cannot add to bridge#{@nic}")
       end
-      return if self.slaves.member?(slave)
-      if current_master = slave.master()
+      return if slaves.member?(slave)
+      if current_master = slave.master
         current_master.remove_slave(slave)
       end
       slave.up
@@ -705,7 +705,7 @@ class ::Nic
       nil
     end
 
-    def self.create(nic,slaves=[])
+    def self.create(nic, slaves = [])
       Chef::Log.info("Creating new bridge #{nic}")
       if self.exists?(nic)
         raise ::ArgumentError.new("#{nic} already exists.")
@@ -747,8 +747,8 @@ class ::Nic
       unless ::Nic.exists?(slave)
         raise ::ArgumentError.new("#{slave} does not exist, cannot add to bridge#{@nic}")
       end
-      return if self.slaves.member?(slave)
-      if current_master = slave.master()
+      return if slaves.member?(slave)
+      if current_master = slave.master
         current_master.remove_slave(slave)
       end
       slave.up
@@ -766,7 +766,7 @@ class ::Nic
     end
 
     def up
-      slaves.each{ |s|s.up }
+      slaves.each(&:up)
       super
     end
 


### PR DESCRIPTION
This backport the recent additions and fixes of the OvsBridge class. It's required by the real fix in the neutron barclamp.
